### PR TITLE
Update towards Inkscape>=1.0 extension API & full python3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,18 @@ from inside Inkscape.
 You have to put these two directories inside your ```~/.config/inkscape``` folder.
 
 ```bash
-curl -L https://github.com/justinotherguy/eggbot_extension/archive/1.2.tar.gz | tar -xz
+git clone https://github.com/justinotherguy/eggbot_extension.git
+# If you want a specific branch:
+#cd eggbot_extension && git checkout BRANCH && cd ..
 mkdir -p ~/.config/inkscape
-cp -r eggbot_extension-1.2/templates ~/.config/inkscape
-cp -r eggbot_extension-1.2/extensions ~/.config/inkscape
+cp -r eggbot_extension/templates ~/.config/inkscape
+cp -r eggbot_extension/extensions ~/.config/inkscape
 ```
 
 ### Dependencies
 
-- Inkscape (obviously)
-- python
+- Inkscape >= 1.0 (obviously)
+- python3
 - python-serial
 
 On Debian or Debian-based distributions (Ubuntu, Mint) use apt-get/aptitude/apt, for example
@@ -25,11 +27,16 @@ sudo apt-get install inkscape python python-serial
 ```
 ### Access Rights
 
-On most GNU/Linux distributions you have to be member of the group `dialout` to use serial ports.
+On most GNU/Linux distributions you have to be member of a certain group to use serial ports.
 
-On Debian/Ubuntu/Mint you can add yourself to the `dialout` group with
+On Debian/Ubuntu/Mint this is the `dialout` group to which you can add yourself with
 ```
 sudo addgroup $USER dialout
+```
+
+On Archlinux it is the `uucp` group to which you can add yourself with
+```
+sudo usermod -aG uucp $USER
 ```
 
 You need to logout/logon or reboot to activate the change.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,20 @@ This Inkscape extension helps you to use the EggDuino based EggBot
 from inside Inkscape.
 
 ## Installation Linux and OSX
-You have to put these two directories inside your ```~/.config/inkscape``` folder.
+You have to put the content of the directories `extensions` and
+`templates` inside the respective folders inside your user extensions folder
+(the ones listed at `Edit` > `Preferences` under `System: User extensions`
+and `System: User templates`, by default
+`~/.config/inkscape/extensions` and `~/.config/inkscape/templates`).
 
 ```bash
 git clone https://github.com/justinotherguy/eggbot_extension.git
 # If you want a specific branch:
 #cd eggbot_extension && git checkout BRANCH && cd ..
-mkdir -p ~/.config/inkscape
-cp -r eggbot_extension/templates ~/.config/inkscape
-cp -r eggbot_extension/extensions ~/.config/inkscape
+# Assuming default paths for extensions and templates
+mkdir -p ~/.config/inkscape/extensions ~/.config/inkscape/templates
+cp -r eggbot_extension/extensions/* ~/.config/inkscape/extensions/
+cp -r eggbot_extension/templates/* ~/.config/inkscape/templates/
 ```
 
 ### Dependencies

--- a/extensions/ebb_motion.py
+++ b/extensions/ebb_motion.py
@@ -31,7 +31,7 @@
 
 import ebb_serial
 import math
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 
 def version():	# Report version number for this document
 	return "0.14"	# Dated February 21, 2018
@@ -289,7 +289,7 @@ def queryVoltage( portName ):
 		EBBversionString = EBBversionString.split("Version ",1)[1]   # Stripped copy, for version # comparisons
 		EBBversionString = EBBversionString.strip()
 		if (EBBversionString != "none"):
-			if (LooseVersion(EBBversionString) >= LooseVersion("2.2.3")):
+			if (parse_version(EBBversionString) >= parse_version("2.2.3")):
 				rawString = (ebb_serial.query( portName, 'QC\r' ))
 				voltagevalue = int(rawString.split(",",1)[1]) # Pick second value only
 				# Typical reading is about 300, for 9 V input.

--- a/extensions/ebb_motion.py
+++ b/extensions/ebb_motion.py
@@ -288,7 +288,7 @@ def queryVoltage( portName ):
 		EBBversionString = ebb_serial.queryVersion(portName) # Full string, human readable
 		EBBversionString = EBBversionString.split("Version ",1)[1]   # Stripped copy, for version # comparisons
 		EBBversionString = EBBversionString.strip()
-		if (EBBversionString is not "none"):
+		if (EBBversionString != "none"):
 			if (LooseVersion(EBBversionString) >= LooseVersion("2.2.3")):
 				rawString = (ebb_serial.query( portName, 'QC\r' ))
 				voltagevalue = int(rawString.split(",",1)[1]) # Pick second value only

--- a/extensions/ebb_serial.py
+++ b/extensions/ebb_serial.py
@@ -44,7 +44,7 @@ def findPort():
 	try:
 		from serial.tools.list_ports import comports
 	except ImportError:
-		comports = None		
+		comports = None  # TODO: global?
 		return None
 	if comports:
 		comPortsList = list(comports())
@@ -193,4 +193,4 @@ def bootload( comPort ):
 			pass 
 
 def queryVersion ( comPort ):
-	return query( comPort, 'V\r' ); 	#Query EBB Version String
+	return query( comPort, 'V\r' ) 	#Query EBB Version String

--- a/extensions/eggbot.inx
+++ b/extensions/eggbot.inx
@@ -4,7 +4,7 @@
   <id>command.evilmadscientist.eggbot.rev280b1</id>
   <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
   <dependency type="executable" location="extensions">eggbot.py</dependency>
-  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <dependency type="executable" location="extensions">inkex</dependency>
   <param name="tab" type="notebook">
   
     <page name="splash" gui-text="Plot">

--- a/extensions/eggbot.inx
+++ b/extensions/eggbot.inx
@@ -192,7 +192,7 @@ https://github.com/evil-mad/EggBot/
     </page>
   </param>
 
-  <effect needs-live-preview="false" needs-document="false">
+  <effect needs-live-preview="false" >
     <object-type>all</object-type>
     <effects-menu>
       <submenu name="EggBot"/>

--- a/extensions/eggbot.inx
+++ b/extensions/eggbot.inx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-  <_name>EggBot Control</_name>
+  <name>EggBot Control</name>
   <id>command.evilmadscientist.eggbot.rev280b1</id>
   <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
   <dependency type="executable" location="extensions">eggbot.py</dependency>
   <dependency type="executable" location="extensions">inkex.py</dependency>
   <param name="tab" type="notebook">
   
-    <page name="splash" _gui-text="Plot">
-<_param indent="1" name="splashpage" type="description" appearance="header">
+    <page name="splash" gui-text="Plot">
+<label indent="1" appearance="header">
 Welcome to the EggBot interface!
-</_param>
-<_param indent="2" name="splashpage2" type="description" xml:space="preserve" >
+</label>
+<label indent="2" xml:space="preserve" >
 Press 'Apply' to begin plotting.
 
 Or, look in the other tabs to adjust your settings
@@ -20,120 +20,120 @@ and use additional EggBot functions.
 Need help? 
 Visit http://wiki.evilmadscientist.com/eggbot
 
-</_param>
+</label>
 </page>
 
-    <page name='setup' _gui-text='Setup'>
+    <page name='setup' gui-text='Setup'>
 
-      <_param name="instructions_setup" type="description" appearance="header">
+      <label appearance="header">
 EggBot: Basic Setup
-</_param>
+</label>
       <param indent="1" name="penUpPosition" type="int" min="0" max="100"
-	     _gui-text="Pen up position, 0-100%:">55</param>
+	     gui-text="Pen up position, 0-100%:">55</param>
       <param indent="1" name="penDownPosition" type="int" min="0" max="100"
-	     _gui-text="Pen down position, 0-100%:">50</param>
+	     gui-text="Pen down position, 0-100%:">50</param>
 
-  <param name="setupType" type="optiongroup"  _gui-text="
-  Action on 'Apply': ">
-	<_option value="toggle-pen"     >Toggle pen up/down</_option>
-	<_option value="align-mode"     >Raise pen, turn off motors</_option>	
+  <param name="setupType" type="optiongroup" gui-text="
+  Action on 'Apply': " appearance="combo">
+	<option value="toggle-pen"     >Toggle pen up/down</option>
+	<option value="align-mode"     >Raise pen, turn off motors</option>
       </param>
-      <_param indent="1" name="instructions_setup3" type="description"
+      <label indent="1"
 	      xml:space="preserve">
 - Raise and lower pen to check the
   pen-up and pen-down positions.
 
 - Raise pen and turn off stepper motors
   for aligning objects in the EggBot.
-</_param>
+</label>
     </page>
 
 
-    <page name='timing' _gui-text='Timing'>
+    <page name='timing' gui-text='Timing'>
 
-<_param name="instructions_timing1" type="description" appearance="header">Movement speeds:</_param>
+<label appearance="header">Movement speeds:</label>
 
 
       <param indent="1" name="penDownSpeed" type="int" min="1" max="10000"
-	   _gui-text="Speed when pen is down (steps/s):">300</param>	
+	   gui-text="Speed when pen is down (steps/s):">300</param>
       <param indent="1" name="penUpSpeed" type="int" min="1" max="10000"
-	   _gui-text="Speed when pen is up (step/s):">400</param>
+	   gui-text="Speed when pen is up (step/s):">400</param>
 
-<_param name="instructions_timing3" type="description" appearance="header">Pen lift and lowering speeds:</_param>
+<label appearance="header">Pen lift and lowering speeds:</label>
 
       <param indent="1" name="ServoUpSpeed" type="int" min="1" max="1600"
-	   _gui-text="Pen raising speed (%/s):">50</param>
+	   gui-text="Pen raising speed (%/s):">50</param>
       <param indent="1" name="penUpDelay" type="int" min="1" max="5000"
-	   _gui-text="Delay after raising pen (ms):">200</param>
+	   gui-text="Delay after raising pen (ms):">200</param>
       <param indent="1" name="ServoDownSpeed" type="int" min="1" max="1600"
-	   _gui-text="Pen lowering speed (%/s):">20</param>
+	   gui-text="Pen lowering speed (%/s):">20</param>
       <param indent="1" name="penDownDelay" type="int" min="1" max="5000"
-	   _gui-text="Delay after lowering pen (ms):">400</param>
-<_param indent="2" name="instructions_timing4" type="description" xml:space="preserve">
+	   gui-text="Delay after lowering pen (ms):">400</param>
+<label indent="2" xml:space="preserve">
 
-(Press 'Apply' to save settings.)</_param>
+(Press 'Apply' to save settings.)</label>
 </page>
 
-<page name='options' _gui-text='Options'>
-<_param name="instructions_options6" type="description" appearance="header">Advanced Options:</_param>
+<page name='options' gui-text='Options'>
+<label appearance="header">Advanced Options:</label>
 
-<param indent="1" name="revPenMotor" type="boolean"
-_gui-text="Reverse motion of Motor 1 (pen)">true</param>	
-<param indent="1" name="revEggMotor" type="boolean"
-_gui-text="Reverse motion of Motor 2 (egg)">true</param> 
-<param indent="1" name="wraparound" type="boolean"
-_gui-text="Egg (x) axis wraps around">true</param>
-<param indent="1" name="startCentered" type="boolean"
-_gui-text="Start with pen centered">true</param>	
-<param indent="1" name="returnToHome" type="boolean"
-_gui-text="Return home when done">true</param> 
-<param indent="1" name="engraving" type="boolean"
-_gui-text="Enable engraver, if attached">false</param>	
+<param indent="1" name="revPenMotor" type="bool"
+gui-text="Reverse motion of Motor 1 (pen)">true</param>
+<param indent="1" name="revEggMotor" type="bool"
+gui-text="Reverse motion of Motor 2 (egg)">true</param>
+<param indent="1" name="wraparound" type="bool"
+gui-text="Egg (x) axis wraps around">true</param>
+<param indent="1" name="startCentered" type="bool"
+gui-text="Start with pen centered">true</param>
+<param indent="1" name="returnToHome" type="bool"
+gui-text="Return home when done">true</param>
+<param indent="1" name="engraving" type="bool"
+gui-text="Enable engraver, if attached">false</param>
 <param indent="1" name="smoothness" type="float"
-_gui-text="Curve smoothing (lower for more):">.2</param>
-<_param indent="2"  name="instructions_options3" type="description" xml:space="preserve">
+gui-text="Curve smoothing (lower for more):">.2</param>
+<label indent="2" xml:space="preserve">
 
-(Press 'Apply' to save settings.)</_param>
+(Press 'Apply' to save settings.)</label>
     </page>
 
 
 	
-    <page name="manual" _gui-text="Manual">
-<_param name="instructions_manual" type="description" appearance="header">EggBot Manual Control</_param>
-<_param indent="1" name="instructions_manual" type="description"  >
+    <page name="manual" gui-text="Manual">
+<label appearance="header">EggBot Manual Control</label>
+<label indent="1" >
 You can use this tab to send "manual" commands
 to the EggBot: Walk the stepper motors, raise or
 lower the pen, enable or disable the motors, or 
 check the circuit board (EBB) firmware version.
-</_param>
+</label>
 
-<param name="manualType" type="optiongroup" appearance="minimal"
-	     _gui-text="               Command: ">
-	<_option value="none"           >- Select -</_option>
-	<_option value="raise-pen"      >Raise the Pen</_option>
-	<_option value="lower-pen"      >Lower the Pen</_option>
-	<_option value="walk-egg-motor" >Walk Motor 2 (egg)</_option>
-	<_option value="walk-pen-motor" >Walk Motor 1 (pen)</_option>
-	<_option value="enable-motors"  >Enable Motors</_option>
-	<_option value="disable-motors" >Disable Motors</_option>
-	<_option value="enable-engraver"  >Engraver On</_option>
-	<_option value="disable-engraver" >Engraver Off</_option>
-	<_option value="version-check"  >Check EBB Version</_option>
-	<_option value="strip-data"     >Strip plotter data from file</_option>
+<param name="manualType" type="optiongroup" appearance="combo"
+	     gui-text="               Command: ">
+	<option value="none"           >- Select -</option>
+	<option value="raise-pen"      >Raise the Pen</option>
+	<option value="lower-pen"      >Lower the Pen</option>
+	<option value="walk-egg-motor" >Walk Motor 2 (egg)</option>
+	<option value="walk-pen-motor" >Walk Motor 1 (pen)</option>
+	<option value="enable-motors"  >Enable Motors</option>
+	<option value="disable-motors" >Disable Motors</option>
+	<option value="enable-engraver"  >Engraver On</option>
+	<option value="disable-engraver" >Engraver Off</option>
+	<option value="version-check"  >Check EBB Version</option>
+	<option value="strip-data"     >Strip plotter data from file</option>
       </param>
 
       <param name="WalkDistance" type="int" min="-32000" max="32000" 
-             _gui-text="               Walk distance (steps):">5</param>
-      <_param indent="3" name="instructions_manual2" type="description"
+             gui-text="               Walk distance (steps):">5</param>
+      <label indent="3"
 	      xml:space="preserve">Walk distances may be positive or negative.
 
 Press 'Apply' to execute the command.
-</_param>
+</label>
     </page>
 
-    <page name="resume" _gui-text="Resume">
-<_param name="instructions_resume1" type="description"  appearance="header">Pause and Resume</_param>
-<_param indent="1" name="instructions_resume2" type="description"> 
+    <page name="resume" gui-text="Resume">
+<label  appearance="header">Pause and Resume</label>
+<label indent="1">
 To pause a plot in progress, press the pause button
 (marked "PRG") on the EggBot's "EBB" controller
 board. After pausing, you can change settings or
@@ -148,14 +148,14 @@ remember to save the document before quitting.
 
 You can resume directly where you paused, or
 after using the Return to Home Corner command.
-</_param>
-      <param name="cancelOnly" type="boolean"
-	     _gui-text="Cancel and return home only">false</param> 
+</label>
+      <param name="cancelOnly" type="bool"
+	     gui-text="Cancel and return home only">false</param>
     </page>		
 
-    <page name="layers" _gui-text="Layers">
-<_param name="instructions_layer" type="description"  appearance="header">Print individual layer(s) </_param>
-<_param  indent="1" name="instructions_layer2" type="description" >
+    <page name="layers" gui-text="Layers">
+<label appearance="header">Print individual layer(s) </label>
+<label  indent="1" >
 Normally, we plot paths from all layers.  
 
 You can also choose to plot a single layer 
@@ -165,13 +165,13 @@ pens between plotting layers.
 Pressing 'Apply' from this frame will plot
 only layers whose names begin with the 
 selected number, which can be up to 100.
-</_param>
+</label>
       <param name="layernumber" type="int" min="0" max="100"
-	     _gui-text="   Plot only layers beginning with: ">1</param>
+	     gui-text="   Plot only layers beginning with: ">1</param>
     </page>			
 
-    <page name="Help" _gui-text="*">
-      <_param name="instructions_general" type="description"
+    <page name="Help" gui-text="*">
+      <label
 	      xml:space="preserve">
 EggBot Control Inkscape extension 
 Release 2.8.1, dated 2017-06-07
@@ -188,19 +188,19 @@ Latest version and issue tracker available at:
 https://github.com/evil-mad/EggBot/
 
 
-</_param>
+</label>
     </page>
   </param>
 
-  <effect needs-live-preview="false" needs-document="no">
+  <effect needs-live-preview="false" needs-document="false">
     <object-type>all</object-type>
     <effects-menu>
-      <submenu _name="EggBot"/>
+      <submenu name="EggBot"/>
     </effects-menu>
   </effect>
 
   <script>
-    <command reldir="extensions" interpreter="python">eggbot.py</command>
+    <command location="inx" interpreter="python">eggbot.py</command>
   </script>
 
 </inkscape-extension>

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -947,7 +947,7 @@ class EggBot( inkex.Effect ):
 		p = inkex.CubicSuperPath( inkex.Path(d) )
 
 		# ...and apply the transformation to each point
-		applyTransformToPath( matTransform, p )
+		inkex.Path( p ).transform(inkex.Transform(matTransform)).to_arrays()
 
 		# p is now a list of lists of cubic beziers [control pt1, control pt2, endpoint]
 		# where the start-point is the last point in the previous segment.

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -25,8 +25,6 @@ from inkex.transforms import Transform
 
 import gettext
 import inkex
-import simplepath
-from inkex.paths import Path
 import string
 import time
 import ebb_serial		# https://github.com/evil-mad/plotink
@@ -612,7 +610,7 @@ class EggBot( inkex.Effect ):
 						a.append( ['l', [0, h]] )
 						a.append( ['l', [-w, 0]] )
 						a.append( ['Z', []] )
-						newpath.set( 'd', str(Path( a )) )
+						newpath.set( 'd', str(inkex.Path( a )) )
 						self.plotPath( newpath, matNew )
 						if ( not self.bStopped ):	#an "index" for resuming plots quickly-- record last complete path
 							self.svgLastPath += 1
@@ -653,7 +651,7 @@ class EggBot( inkex.Effect ):
 						a = []
 						a.append( ['M', [x1, y1]] )
 						a.append( ['L', [x2, y2]] )
-						newpath.set( 'd', str(Path( a )) )
+						newpath.set( 'd', str(inkex.Path( a )) )
 						self.plotPath( newpath, matNew )
 						if ( not self.bStopped ):	#an "index" for resuming plots quickly-- record last complete path
 							self.svgLastPath += 1
@@ -943,10 +941,10 @@ class EggBot( inkex.Effect ):
 
 		d = path.get( 'd' )
 
-		if len( simplepath.parsePath( d ) ) == 0:
+		if len( inkex.Path( d ).to_arrays() ) == 0:
 			return
 
-		p = cubicsuperpath.parsePath( d )
+		p = inkex.CubicSuperPath( inkex.Path(d) )
 
 		# ...and apply the transformation to each point
 		applyTransformToPath( matTransform, p )

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -834,7 +834,7 @@ class EggBot( inkex.Effect ):
 					pass
 				elif (node.tag == inkex.addNS( 'text', 'svg' ) or node.tag == 'text' or
 					node.tag == inkex.addNS( 'flowRoot', 'svg' ) or node.tag == 'flowRoot'):
-					if not self.warnings.has_key( 'text' ):
+					if 'text' not in self.warnings:
 						inkex.errormsg( gettext.gettext( 'Warning: in layer "' + 
 							self.sCurrentLayerName + '" unable to draw text; ' +
 							'please convert it to a path first.  Consider using the ' +
@@ -843,7 +843,7 @@ class EggBot( inkex.Effect ):
 						self.warnings['text'] = 1
 					pass
 				elif node.tag == inkex.addNS( 'image', 'svg' ) or node.tag == 'image':
-					if not self.warnings.has_key( 'image' ):
+					if 'image' not in self.warnings:
 						inkex.errormsg( gettext.gettext( 'Warning: in layer "' + 
 							self.sCurrentLayerName + '" unable to draw bitmap images; ' +
 							'please convert them to line art first.  Consider using the "Trace bitmap..." ' +
@@ -876,7 +876,7 @@ class EggBot( inkex.Effect ):
 					# be very useful.
 					pass
 				else:
-					if not self.warnings.has_key( str( node.tag ) ):
+					if str( node.tag ) not in self.warnings:
 						t = str( node.tag ).split( '}' )
 						inkex.errormsg( gettext.gettext( 'Warning: in layer "' + 
 							self.sCurrentLayerName + '" unable to draw <' + str( t[-1] ) +

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -21,6 +21,7 @@
 # TODO: Add and honor advisory locking around device open/close for non Win32
 
 from simpletransform import *
+from inkex.transforms import Transform
 
 import gettext
 import inkex
@@ -432,7 +433,7 @@ class EggBot( inkex.Effect ):
 			if ( float(vinfo[2]) != 0 ) and ( float(vinfo[3]) != 0 ):
 				sx = self.svgWidth / float( vinfo[2] )
 				sy = self.svgHeight / float( vinfo[3] )
-				self.svgTransform = parseTransform( 'scale(%f,%f) translate(%f,%f)' % (sx, sy, -float( vinfo[0] ), -float( vinfo[1] ) ) )
+				self.svgTransform = Transform( 'scale(%f,%f) translate(%f,%f)' % (sx, sy, -float( vinfo[0] ), -float( vinfo[1] ) ) ).matrix
 
 		self.ServoSetup()
 		ebb_motion.sendEnableMotors(self.serialPort, 1) # 16X microstepping
@@ -500,7 +501,7 @@ class EggBot( inkex.Effect ):
 				continue
 
 			# first apply the current matrix transform to this node's tranform
-			matNew = composeTransform( matCurrent, parseTransform( node.get( "transform" ) ) )
+			matNew = composeTransform( matCurrent, Transform( node.get( "transform" ) ).matrix )
 
 			if node.tag == inkex.addNS( 'g', 'svg' ) or node.tag == 'g':
 
@@ -536,7 +537,7 @@ class EggBot( inkex.Effect ):
 						y = float( node.get( 'y', '0' ) )
 						# Note: the transform has already been applied
 						if ( x != 0 ) or (y != 0 ):
-							matNew2 = composeTransform( matNew, parseTransform( 'translate(%f,%f)' % (x,y) ) )
+							matNew2 = composeTransform( matNew, Transform( 'translate(%f,%f)' % (x,y) ).matrix )
 						else:
 							matNew2 = matNew
 						v = node.get( 'visibility', v )

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -20,13 +20,13 @@
 
 # TODO: Add and honor advisory locking around device open/close for non Win32
 
-from simpletransform import *
 from inkex.transforms import Transform
 
 import gettext
 import inkex
 import string
 import time
+import math
 import ebb_serial		# https://github.com/evil-mad/plotink
 import plot_utils		# https://github.com/evil-mad/plotink
 import ebb_motion		# https://github.com/evil-mad/plotink	Requires version 0.2 or newer.

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -48,88 +48,88 @@ class EggBot( inkex.Effect ):
 	def __init__( self ):
 		inkex.Effect.__init__( self )
 
-		self.OptionParser.add_option( "--smoothness",
-			action="store", type="float",
+		self.arg_parser.add_argument( "--smoothness",
+			type=float,
 			dest="smoothness", default=.2,
 			help="Smoothness of curves" )
-		self.OptionParser.add_option( "--startCentered",
-			action="store", type="inkbool",
+		self.arg_parser.add_argument( "--startCentered",
+			type=inkex.Boolean,
 			dest="startCentered", default=True,
 			help="Start plot with pen centered in the y-axis." )
-		self.OptionParser.add_option( "--returnToHome",
-			action="store", type="inkbool",
+		self.arg_parser.add_argument( "--returnToHome",
+			type=inkex.Boolean,
 			dest="returnToHome", default=True,
 			help="Return to home at end of plot." )
-		self.OptionParser.add_option( "--wraparound",
-			action="store", type="inkbool",
+		self.arg_parser.add_argument( "--wraparound",
+			type=inkex.Boolean,
 			dest="wraparound", default=True,
 			help="Egg (x) axis wraps around-- take shortcuts!" )
-		self.OptionParser.add_option( "--penUpSpeed",
-			action="store", type="int",
+		self.arg_parser.add_argument( "--penUpSpeed",
+			type=int,
 			dest="penUpSpeed", default=F_DEFAULT_SPEED,
 			help="Speed (step/sec) while pen is up." )
-		self.OptionParser.add_option( "--penDownSpeed",
-			action="store", type="int",
+		self.arg_parser.add_argument( "--penDownSpeed",
+			type=int,
 			dest="penDownSpeed", default=F_DEFAULT_SPEED,
 			help="Speed (step/sec) while pen is down." )
-		self.OptionParser.add_option( "--penDownDelay",
-			action="store", type="int",
+		self.arg_parser.add_argument( "--penDownDelay",
+			type=int,
 			dest="penDownDelay", default=N_PEN_DOWN_DELAY,
 			help="Delay after pen down (msec)." )
-		self.OptionParser.add_option( "--penUpDelay",
-			action="store", type="int",
+		self.arg_parser.add_argument( "--penUpDelay",
+			type=int,
 			dest="penUpDelay", default=N_PEN_UP_DELAY,
 			help="Delay after pen up (msec)." )
-		self.OptionParser.add_option( "--engraving",
-			action="store", type="inkbool",
+		self.arg_parser.add_argument( "--engraving",
+			type=inkex.Boolean,
 			dest="engraving", default=False,
 			help="Enable optional engraving tool." )
-		self.OptionParser.add_option( "--tab",
-			action="store", type="string",
+		self.arg_parser.add_argument( "--tab",
+			type=str,
 			dest="tab", default="controls",
 			help="The active tab when Apply was pressed" )
-		self.OptionParser.add_option( "--penUpPosition",
-			action="store", type="int",
+		self.arg_parser.add_argument( "--penUpPosition",
+			type=int,
 			dest="penUpPosition", default=N_PEN_UP_POS,
 			help="Position of pen when lifted" )
-		self.OptionParser.add_option( "--ServoDownSpeed",
-			action="store", type="int",
+		self.arg_parser.add_argument( "--ServoDownSpeed",
+			type=int,
 			dest="ServoDownSpeed", default=N_SERVOSPEED,
 			help="Rate of lowering pen " )
-		self.OptionParser.add_option( "--ServoUpSpeed",
-			action="store", type="int",
+		self.arg_parser.add_argument( "--ServoUpSpeed",
+			type=int,
 			dest="ServoUpSpeed", default=N_SERVOSPEED,
 			help="Rate of lifting pen " )
-		self.OptionParser.add_option( "--penDownPosition",
-			action="store", type="int",
+		self.arg_parser.add_argument( "--penDownPosition",
+			type=int,
 			dest="penDownPosition", default=N_PEN_DOWN_POS,
 			help="Position of pen when lowered" )
-		self.OptionParser.add_option( "--layernumber",
-			action="store", type="int",
+		self.arg_parser.add_argument( "--layernumber",
+			type=int,
 			dest="layernumber", default=N_DEFAULT_LAYER,
 			help="Selected layer for multilayer plotting" )
-		self.OptionParser.add_option( "--setupType",
-			action="store", type="string",
+		self.arg_parser.add_argument( "--setupType",
+			type=str,
 			dest="setupType", default="controls",
 			help="The active option when Apply was pressed" )
-		self.OptionParser.add_option( "--manualType",
-			action="store", type="string",
+		self.arg_parser.add_argument( "--manualType",
+			type=str,
 			dest="manualType", default="controls",
 			help="The active option when Apply was pressed" )
-		self.OptionParser.add_option( "--WalkDistance",
-			action="store", type="int",
+		self.arg_parser.add_argument( "--WalkDistance",
+			type=int,
 			dest="WalkDistance", default=N_WALK_DEFAULT,
 			help="Selected layer for multilayer plotting" )
-		self.OptionParser.add_option( "--cancelOnly",
-			action="store", type="inkbool",
+		self.arg_parser.add_argument( "--cancelOnly",
+			type=inkex.Boolean,
 			dest="cancelOnly", default=False,
 			help="Cancel plot and return home only." )
-		self.OptionParser.add_option( "--revPenMotor",
-			action="store", type="inkbool",
+		self.arg_parser.add_argument( "--revPenMotor",
+			type=inkex.Boolean,
 			dest="revPenMotor", default=False,
 			help="Reverse motion of pen motor." )
-		self.OptionParser.add_option( "--revEggMotor",
-			action="store", type="inkbool",
+		self.arg_parser.add_argument( "--revEggMotor",
+			type=inkex.Boolean,
 			dest="revEggMotor", default=False,
 			help="Reverse motion of egg motor." )
 

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -606,11 +606,11 @@ class EggBot( inkex.Effect ):
 						if t:
 							newpath.set( 'transform', t )
 						a = []
-						a.append( ['M ', [x, y]] )
-						a.append( [' l ', [w, 0]] )
-						a.append( [' l ', [0, h]] )
-						a.append( [' l ', [-w, 0]] )
-						a.append( [' Z', []] )
+						a.append( ['M', [x, y]] )
+						a.append( ['l', [w, 0]] )
+						a.append( ['l', [0, h]] )
+						a.append( ['l', [-w, 0]] )
+						a.append( ['Z', []] )
 						newpath.set( 'd', str(Path( a )) )
 						self.plotPath( newpath, matNew )
 						if ( not self.bStopped ):	#an "index" for resuming plots quickly-- record last complete path
@@ -650,8 +650,8 @@ class EggBot( inkex.Effect ):
 						if t:
 							newpath.set( 'transform', t )
 						a = []
-						a.append( ['M ', [x1, y1]] )
-						a.append( [' L ', [x2, y2]] )
+						a.append( ['M', [x1, y1]] )
+						a.append( ['L', [x2, y2]] )
 						newpath.set( 'd', str(Path( a )) )
 						self.plotPath( newpath, matNew )
 						if ( not self.bStopped ):	#an "index" for resuming plots quickly-- record last complete path
@@ -691,10 +691,10 @@ class EggBot( inkex.Effect ):
 						# Issue 29: pre 2.5.? versions of Python do not have
 						#    "statement-1 if expression-1 else statement-2"
 						# which came out of PEP 308, Conditional Expressions
-						#d = "".join( ["M " + pa[i] if i == 0 else " L " + pa[i] for i in range( 0, len( pa ) )] )
-						d = "M " + pa[0]
+						#d = "".join( ["M" + pa[i] if i == 0 else "L" + pa[i] for i in range( 0, len( pa ) )] )
+						d = "M" + pa[0]
 						for i in range( 1, len( pa ) ):
-							d += " L " + pa[i]
+							d += "L" + pa[i]
 						newpath = lxml.etree.Element( inkex.addNS( 'path', 'svg' ) )
 						newpath.set( 'd', d );
 						s = node.get( 'style' )
@@ -737,11 +737,11 @@ class EggBot( inkex.Effect ):
 						# Issue 29: pre 2.5.? versions of Python do not have
 						#    "statement-1 if expression-1 else statement-2"
 						# which came out of PEP 308, Conditional Expressions
-						#d = "".join( ["M " + pa[i] if i == 0 else " L " + pa[i] for i in range( 0, len( pa ) )] )
-						d = "M " + pa[0]
+						#d = "".join( ["M" + pa[i] if i == 0 else "L" + pa[i] for i in range( 0, len( pa ) )] )
+						d = "M" + pa[0]
 						for i in range( 1, len( pa ) ):
-							d += " L " + pa[i]
-						d += " Z"
+							d += "L" + pa[i]
+						d += "Z"
 						newpath = lxml.etree.Element( inkex.addNS( 'path', 'svg' ) )
 						newpath.set( 'd', d );
 						s = node.get( 'style' )

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -21,6 +21,7 @@
 # TODO: Add and honor advisory locking around device open/close for non Win32
 
 from inkex.transforms import Transform
+import inkex.bezier
 
 import gettext
 import inkex
@@ -941,13 +942,16 @@ class EggBot( inkex.Effect ):
 		p = inkex.CubicSuperPath( inkex.Path(d) )
 
 		# ...and apply the transformation to each point
-		p = inkex.Path( p ).transform(inkex.Transform(matTransform)).to_arrays()
+		p = p.transform(inkex.Transform(matTransform))
+		# ...and sub-divide the super path into smaller curves, each of which
+		# 	is approximately a straight line within a given tolerance
+		# 	(the "smoothness")
+		inkex.bezier.cspsubdiv(p, self.options.smoothness)
 
 		# p is now a list of lists of cubic beziers [control pt1, control pt2, endpoint]
 		# where the start-point is the last point in the previous segment.
 		for sp in p:
 
-			plot_utils.subdivideCubicPath( sp, self.options.smoothness )
 			nIndex = 0
 
 			for csp in sp:

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -33,6 +33,8 @@ import ebb_motion		# https://github.com/evil-mad/plotink	Requires version 0.2 or
 
 import eggbot_conf		#Some settings can be changed here.
 
+import lxml.etree
+
 F_DEFAULT_SPEED = 1
 N_PEN_DOWN_DELAY = 400	# delay (ms) for the pen to go down before the next move
 N_PEN_UP_DELAY = 400	# delay (ms) for the pen to up down before the next move
@@ -247,7 +249,7 @@ class EggBot( inkex.Effect ):
 		self.svgDataRead = False
 		self.recursiveEggbotDataScan( self.svg )
 		if ( not self.svgDataRead ):    #if there is no eggbot data, add some:
-			eggbotlayer = inkex.etree.SubElement( self.svg, 'eggbot' )
+			eggbotlayer = lxml.etree.SubElement( self.svg, 'eggbot' )
 			eggbotlayer.set( 'layer', str( 0 ) )
 			eggbotlayer.set( 'node', str( 0 ) )
 			eggbotlayer.set( 'lastpath', str( 0 ) )
@@ -591,7 +593,7 @@ class EggBot( inkex.Effect ):
 						doWePlotThisPath = True
 					if (doWePlotThisPath):
 						self.pathcount += 1
-						newpath = inkex.etree.Element( inkex.addNS( 'path', 'svg' ) )
+						newpath = lxml.etree.Element( inkex.addNS( 'path', 'svg' ) )
 						x = float( node.get( 'x' ) )
 						y = float( node.get( 'y' ) )
 						w = float( node.get( 'width' ) )
@@ -635,7 +637,7 @@ class EggBot( inkex.Effect ):
 						doWePlotThisPath = True
 					if (doWePlotThisPath):
 						self.pathcount += 1
-						newpath = inkex.etree.Element( inkex.addNS( 'path', 'svg' ) )
+						newpath = lxml.etree.Element( inkex.addNS( 'path', 'svg' ) )
 						x1 = float( node.get( 'x1' ) )
 						y1 = float( node.get( 'y1' ) )
 						x2 = float( node.get( 'x2' ) )
@@ -692,7 +694,7 @@ class EggBot( inkex.Effect ):
 						d = "M " + pa[0]
 						for i in range( 1, len( pa ) ):
 							d += " L " + pa[i]
-						newpath = inkex.etree.Element( inkex.addNS( 'path', 'svg' ) )
+						newpath = lxml.etree.Element( inkex.addNS( 'path', 'svg' ) )
 						newpath.set( 'd', d );
 						s = node.get( 'style' )
 						if s:
@@ -739,7 +741,7 @@ class EggBot( inkex.Effect ):
 						for i in range( 1, len( pa ) ):
 							d += " L " + pa[i]
 						d += " Z"
-						newpath = inkex.etree.Element( inkex.addNS( 'path', 'svg' ) )
+						newpath = lxml.etree.Element( inkex.addNS( 'path', 'svg' ) )
 						newpath.set( 'd', d );
 						s = node.get( 'style' )
 						if s:
@@ -803,7 +805,7 @@ class EggBot( inkex.Effect ):
 								'0 1 0 %f,%f ' % ( x2, cy ) + \
 								'A %f,%f ' % ( rx, ry ) + \
 								'0 1 0 %f,%f' % ( x1, cy )
-							newpath = inkex.etree.Element( inkex.addNS( 'path', 'svg' ) )
+							newpath = lxml.etree.Element( inkex.addNS( 'path', 'svg' ) )
 							newpath.set( 'd', d );
 							s = node.get( 'style' )
 							if s:

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -868,7 +868,7 @@ class EggBot( inkex.Effect ):
 				elif node.tag == inkex.addNS( 'color-profile', 'svg' ) or node.tag == 'color-profile':
 					# Gamma curves, color temp, etc. are not relevant to single color output
 					pass
-				elif not isinstance( node.tag, basestring ):
+				elif not isinstance( node.tag, str ):
 					# This is likely an XML processing instruction such as an XML
 					# comment.  lxml uses a function reference for such node tags
 					# and as such the node tag is likely not a printable string.

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -891,7 +891,7 @@ class EggBot( inkex.Effect ):
 
 		TempNumString = 'x'
 		stringPos = 1
-		CurrentLayerName = str(strLayerName.encode( 'ascii', 'ignore' )).lstrip() #remove leading whitespace
+		CurrentLayerName = str(strLayerName).lstrip() #remove leading whitespace
 		
 		# Look at layer name.  Sample first character, then first two, and
 		# so on, until the string ends or the string no longer consists of

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -1166,4 +1166,4 @@ class EggBot( inkex.Effect ):
 				self.bStopped = True
 				return
 e = EggBot()
-e.affect()
+e.run()

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -24,7 +24,6 @@ from inkex.transforms import Transform
 
 import gettext
 import inkex
-import string
 import time
 import math
 import ebb_serial		# https://github.com/evil-mad/plotink
@@ -897,7 +896,7 @@ class EggBot( inkex.Effect ):
 
 		TempNumString = 'x'
 		stringPos = 1
-		CurrentLayerName = string.lstrip( strLayerName.encode( 'ascii', 'ignore' ) ) #remove leading whitespace
+		CurrentLayerName = str(strLayerName.encode( 'ascii', 'ignore' )).lstrip() #remove leading whitespace
 		
 		# Look at layer name.  Sample first character, then first two, and
 		# so on, until the string ends or the string no longer consists of

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -478,7 +478,7 @@ class EggBot( inkex.Effect ):
 				self.engraverOff()
 
 	def recursivelyTraverseSvg( self, aNodeList,
-			matCurrent=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+			matCurrent=((1.0, 0.0, 0.0), (0.0, 1.0, 0.0)),
 			parent_visibility='visible' ):
 		"""
 		Recursively traverse the svg file to plot out all of the
@@ -501,7 +501,7 @@ class EggBot( inkex.Effect ):
 				continue
 
 			# first apply the current matrix transform to this node's tranform
-			matNew = composeTransform( matCurrent, Transform( node.get( "transform" ) ).matrix )
+			matNew = ( Transform(matCurrent) * Transform( node.get( "transform" ) ) ).matrix
 
 			if node.tag == inkex.addNS( 'g', 'svg' ) or node.tag == 'g':
 
@@ -537,7 +537,7 @@ class EggBot( inkex.Effect ):
 						y = float( node.get( 'y', '0' ) )
 						# Note: the transform has already been applied
 						if ( x != 0 ) or (y != 0 ):
-							matNew2 = composeTransform( matNew, Transform( 'translate(%f,%f)' % (x,y) ).matrix )
+							matNew2 = ( Transform(matNew) * Transform( 'translate(%f,%f)' % (x,y) ) ).matrix
 						else:
 							matNew2 = matNew
 						v = node.get( 'visibility', v )

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -184,14 +184,14 @@ class EggBot( inkex.Effect ):
 		self.svg = self.document.getroot()
 		self.CheckSVGforEggbotData()
 
-		if ((self.options.tab == '"Help"') or (self.options.tab == '"options"')  or (self.options.tab == '"timing"')):
+		if ((self.options.tab == 'Help') or (self.options.tab == 'options')  or (self.options.tab == 'timing')):
 			pass
 		else:
 			self.serialPort = ebb_serial.openPort()
 			if self.serialPort is None:
 				inkex.errormsg( gettext.gettext( "Failed to connect to EggBot. :(" ) )
 
-			if self.options.tab == '"splash"':
+			if self.options.tab == 'splash':
 				self.allLayers = True
 				self.plotCurrentLayer = True
 				self.svgNodeCount = 0
@@ -200,7 +200,7 @@ class EggBot( inkex.Effect ):
 				self.svgLayer = 12345;  # indicate that we are plotting all layers.
 				self.plotToEggBot()
 	
-			elif self.options.tab == '"resume"':
+			elif self.options.tab == 'resume':
 				unused_button = ebb_motion.QueryPRGButton(self.serialPort)	#Query if button pressed
 				self.resumePlotSetup()
 				if self.resumeMode:
@@ -210,7 +210,7 @@ class EggBot( inkex.Effect ):
 				else:
 					inkex.errormsg( gettext.gettext( "Truly sorry, there does not seem to be any in-progress plot to resume." ) )
 	
-			elif self.options.tab == '"layers"':
+			elif self.options.tab == 'layers':
 				self.allLayers = False
 				self.plotCurrentLayer = False
 				self.LayersPlotted = 0
@@ -222,10 +222,10 @@ class EggBot( inkex.Effect ):
 				if ( self.LayersPlotted == 0 ):
 					inkex.errormsg( gettext.gettext( "Truly sorry, but I did not find any numbered layers to plot." ) )
 					
-			elif self.options.tab == '"setup"':
-				self.setupCommand()	
+			elif self.options.tab == 'setup':
+				self.setupCommand()
 
-			elif self.options.tab == '"manual"':
+			elif self.options.tab == 'manual':
 				if self.options.manualType == "strip-data":
 					for node in self.svg.xpath( '//svg:WCB', namespaces=inkex.NSS ):
 						self.svg.remove( node )
@@ -239,7 +239,7 @@ class EggBot( inkex.Effect ):
 			if self.serialPort is not None:
 				ebb_motion.doTimedPause(self.serialPort, 10) #Pause a moment for underway commands to finish...
 				ebb_serial.closePort(self.serialPort)	
-				
+
 		self.svgDataRead = False
 		self.UpdateSVGEggbotData( self.svg )
 		return
@@ -1005,7 +1005,7 @@ class EggBot( inkex.Effect ):
 			if ( not self.resumeMode): # or if we're resuming.
 				ebb_motion.sendPenUp(self.serialPort, self.options.penUpDelay )				
 				if (self.options.penUpDelay  > 15):
-					if self.options.tab != '"manual"':
+					if self.options.tab != 'manual':
 						time.sleep(float(self.options.penUpDelay - 10)/1000.0)  #pause before issuing next command
 				self.bPenIsUp = True
 
@@ -1018,7 +1018,7 @@ class EggBot( inkex.Effect ):
 						self.engraverOn() # will check self.enableEngraver
 				ebb_motion.sendPenDown(self.serialPort, self.options.penDownDelay )						
 				if (self.options.penUpDelay  > 15):
-					if self.options.tab != '"manual"':
+					if self.options.tab != 'manual':
 						time.sleep(float(self.options.penDownDelay - 10)/1000.0)  #pause before issuing next command
 
 	def engraverOff( self ):

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -158,9 +158,6 @@ class EggBot( inkex.Effect ):
 		self.svgTotalDeltaX = int( 0 )
 		self.svgTotalDeltaY = int( 0 )
 		self.serialPort = None
-		
-		nDeltaX = 0
-		nDeltaY = 0
 
 		self.svgWidth = float( eggbot_conf.N_PAGE_WIDTH )
 		self.svgHeight = float( eggbot_conf.N_PAGE_HEIGHT )
@@ -196,12 +193,12 @@ class EggBot( inkex.Effect ):
 				self.plotCurrentLayer = True
 				self.svgNodeCount = 0
 				self.svgLastPath = 0
-				unused_button = ebb_motion.QueryPRGButton(self.serialPort)	#Query if button pressed
-				self.svgLayer = 12345;  # indicate that we are plotting all layers.
+				_unused_button = ebb_motion.QueryPRGButton(self.serialPort)	#Query if button pressed
+				self.svgLayer = 12345  # indicate that we are plotting all layers.
 				self.plotToEggBot()
 	
 			elif self.options.tab == 'resume':
-				unused_button = ebb_motion.QueryPRGButton(self.serialPort)	#Query if button pressed
+				_unused_button = ebb_motion.QueryPRGButton(self.serialPort)	#Query if button pressed
 				self.resumePlotSetup()
 				if self.resumeMode:
 					self.plotToEggBot()
@@ -215,8 +212,8 @@ class EggBot( inkex.Effect ):
 				self.plotCurrentLayer = False
 				self.LayersPlotted = 0
 				self.svgLastPath = 0
-				unused_button = ebb_motion.QueryPRGButton(self.serialPort)	#Query if button pressed
-				self.svgNodeCount = 0;
+				_unused_button = ebb_motion.QueryPRGButton(self.serialPort)	#Query if button pressed
+				self.svgNodeCount = 0
 				self.svgLayer = self.options.layernumber
 				self.plotToEggBot()
 				if ( self.LayersPlotted == 0 ):
@@ -603,12 +600,11 @@ class EggBot( inkex.Effect ):
 						t = node.get( 'transform' )
 						if t:
 							newpath.set( 'transform', t )
-						a = []
-						a.append( ['M', [x, y]] )
-						a.append( ['l', [w, 0]] )
-						a.append( ['l', [0, h]] )
-						a.append( ['l', [-w, 0]] )
-						a.append( ['Z', []] )
+						a = [['M', [x, y]],
+							 ['l', [w, 0]],
+							 ['l', [0, h]],
+							 ['l', [-w, 0]],
+							 ['Z', []]]
 						newpath.set( 'd', str(inkex.Path( a )) )
 						self.plotPath( newpath, matNew )
 						if ( not self.bStopped ):	#an "index" for resuming plots quickly-- record last complete path
@@ -647,9 +643,8 @@ class EggBot( inkex.Effect ):
 						t = node.get( 'transform' )
 						if t:
 							newpath.set( 'transform', t )
-						a = []
-						a.append( ['M', [x1, y1]] )
-						a.append( ['L', [x2, y2]] )
+						a = [['M', [x1, y1]],
+							 ['L', [x2, y2]]]
 						newpath.set( 'd', str(inkex.Path( a )) )
 						self.plotPath( newpath, matNew )
 						if ( not self.bStopped ):	#an "index" for resuming plots quickly-- record last complete path
@@ -694,7 +689,7 @@ class EggBot( inkex.Effect ):
 						for i in range( 1, len( pa ) ):
 							d += "L" + pa[i]
 						newpath = lxml.etree.Element( inkex.addNS( 'path', 'svg' ) )
-						newpath.set( 'd', d );
+						newpath.set( 'd', d )
 						s = node.get( 'style' )
 						if s:
 							newpath.set( 'style', s )
@@ -741,7 +736,7 @@ class EggBot( inkex.Effect ):
 							d += "L" + pa[i]
 						d += "Z"
 						newpath = lxml.etree.Element( inkex.addNS( 'path', 'svg' ) )
-						newpath.set( 'd', d );
+						newpath.set( 'd', d )
 						s = node.get( 'style' )
 						if s:
 							newpath.set( 'style', s )
@@ -805,7 +800,7 @@ class EggBot( inkex.Effect ):
 								'A %f,%f ' % ( rx, ry ) + \
 								'0 1 0 %f,%f' % ( x1, cy )
 							newpath = lxml.etree.Element( inkex.addNS( 'path', 'svg' ) )
-							newpath.set( 'd', d );
+							newpath.set( 'd', d )
 							s = node.get( 'style' )
 							if s:
 								newpath.set( 'style', s )
@@ -926,7 +921,7 @@ class EggBot( inkex.Effect ):
 		'''
 		self.svgHeight = plot_utils.getLength( self, 'height', eggbot_conf.N_PAGE_HEIGHT )
 		self.svgWidth = plot_utils.getLength( self, 'width', eggbot_conf.N_PAGE_WIDTH )
-		if ( self.svgHeight == None ) or ( self.svgWidth == None ):
+		if (self.svgHeight is None) or (self.svgWidth is None):
 			return False
 		else:
 			return True
@@ -1157,7 +1152,7 @@ class EggBot( inkex.Effect ):
 				bNoResponseFromEbb = False
 				
 			if strButton[0] == '1': #button pressed, or simulated pressed because of communication error to allow resume
-				self.svgNodeCount = self.nodeCount;
+				self.svgNodeCount = self.nodeCount
 				if bNoResponseFromEbb:
 					inkex.errormsg( 'Plot halted by communication error after node number ' + str( self.nodeCount ) + '.' )
 				else:

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -25,6 +25,7 @@ from simpletransform import *
 import gettext
 import inkex
 import simplepath
+from inkex.paths import Path
 import string
 import time
 import ebb_serial		# https://github.com/evil-mad/plotink
@@ -610,7 +611,7 @@ class EggBot( inkex.Effect ):
 						a.append( [' l ', [0, h]] )
 						a.append( [' l ', [-w, 0]] )
 						a.append( [' Z', []] )
-						newpath.set( 'd', simplepath.formatPath( a ) )
+						newpath.set( 'd', str(Path( a )) )
 						self.plotPath( newpath, matNew )
 						if ( not self.bStopped ):	#an "index" for resuming plots quickly-- record last complete path
 							self.svgLastPath += 1
@@ -651,7 +652,7 @@ class EggBot( inkex.Effect ):
 						a = []
 						a.append( ['M ', [x1, y1]] )
 						a.append( [' L ', [x2, y2]] )
-						newpath.set( 'd', simplepath.formatPath( a ) )
+						newpath.set( 'd', str(Path( a )) )
 						self.plotPath( newpath, matNew )
 						if ( not self.bStopped ):	#an "index" for resuming plots quickly-- record last complete path
 							self.svgLastPath += 1

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -941,7 +941,7 @@ class EggBot( inkex.Effect ):
 		p = inkex.CubicSuperPath( inkex.Path(d) )
 
 		# ...and apply the transformation to each point
-		inkex.Path( p ).transform(inkex.Transform(matTransform)).to_arrays()
+		p = inkex.Path( p ).transform(inkex.Transform(matTransform)).to_arrays()
 
 		# p is now a list of lists of cubic beziers [control pt1, control pt2, endpoint]
 		# where the start-point is the last point in the previous segment.

--- a/extensions/eggbot.py
+++ b/extensions/eggbot.py
@@ -496,7 +496,7 @@ class EggBot( inkex.Effect ):
 				continue
 
 			# first apply the current matrix transform to this node's tranform
-			matNew = ( Transform(matCurrent) * Transform( node.get( "transform" ) ) ).matrix
+			matNew = ( Transform(matCurrent) @ Transform( node.get( "transform" ) ) ).matrix
 
 			if node.tag == inkex.addNS( 'g', 'svg' ) or node.tag == 'g':
 
@@ -532,7 +532,7 @@ class EggBot( inkex.Effect ):
 						y = float( node.get( 'y', '0' ) )
 						# Note: the transform has already been applied
 						if ( x != 0 ) or (y != 0 ):
-							matNew2 = ( Transform(matNew) * Transform( 'translate(%f,%f)' % (x,y) ) ).matrix
+							matNew2 = ( Transform(matNew) @ Transform( 'translate(%f,%f)' % (x,y) ) ).matrix
 						else:
 							matNew2 = matNew
 						v = node.get( 'visibility', v )

--- a/extensions/eggbot_acrostic.inx
+++ b/extensions/eggbot_acrostic.inx
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-  <_name>Name Poem</_name>
+  <name>Name Poem</name>
   <id>command.eggbot.contributed.eggbot_acrostic101</id>
 <!--
   <dependency type="executable" location="extensions">hersheydata.py</dependency> -->
-  <dependency type="executable" location="extensions">simplestyle.py</dependency>
   <dependency type="executable" location="extensions">eggbot_acrostic.py</dependency>
   <dependency type="executable" location="extensions">inkex.py</dependency>
   <param name="tab" type="notebook">
-    <page name="splash" _gui-text="Render Text">
-      <_param name="stuff" type="description">
+    <page name="splash" gui-text="Render Text">
+      <label>
 This extension helps you to draw a "name poem" (an acrostic
 poem).  Each line of poetry will be drawn horizontally, with
 the second line below the first, and so on.
@@ -17,85 +16,85 @@ the second line below the first, and so on.
 For each line of poetry, the first character will be drawn
 using the "Leading font".  The remainder of the line will be
 drawn using the "Secondary font".
-</_param>
-      <param name="stretch" type="boolean" _gui-text="Stretch the text horizontally to account for the egg's geometry? ">true</param>
-      <param name="flip" type="boolean" _gui-text="Plot with the egg's bottom at the egg motor? ">false</param>
-      <param name="face1" type="optiongroup" appearance="minimal" _gui-text="Leading font ">
-	<_option value="scriptc">Script medium</_option>
-	<_option value="scripts">Script 1-stroke</_option>
-	<_option value="cursive">Script 1-stroke (alt)</_option>
+</label>
+      <param name="stretch" type="bool" gui-text="Stretch the text horizontally to account for the egg's geometry? ">true</param>
+      <param name="flip" type="bool" gui-text="Plot with the egg's bottom at the egg motor? ">false</param>
+      <param name="face1" type="optiongroup" appearance="combo" gui-text="Leading font ">
+	<option value="scriptc">Script medium</option>
+	<option value="scripts">Script 1-stroke</option>
+	<option value="cursive">Script 1-stroke (alt)</option>
 
-	<_option value="futural">Sans 1-stroke</_option>
-	<_option value="futuram">Sans bold</_option> 
+	<option value="futural">Sans 1-stroke</option>
+	<option value="futuram">Sans bold</option> 
 
-	<_option value="timesr">Serif medium</_option>
-	<_option value="timesi">Serif medium italic</_option>
-	<_option value="timesib">Serif bold italic</_option>
-	<_option value="timesrb">Serif bold</_option>
+	<option value="timesr">Serif medium</option>
+	<option value="timesi">Serif medium italic</option>
+	<option value="timesib">Serif bold italic</option>
+	<option value="timesrb">Serif bold</option>
 
-	<_option value="gothiceng">Gothic English</_option>
-	<_option value="gothicger">Gothic German</_option>
-	<_option value="gothicita">Gothic Italian</_option>	   
+	<option value="gothiceng">Gothic English</option>
+	<option value="gothicger">Gothic German</option>
+	<option value="gothicita">Gothic Italian</option>	   
 
-	<_option value="greek">Greek 1-stroke</_option>
-	<_option value="timesg">Greek medium</_option>
-	<_option value="cyrillic">Cyrillic</_option>		
-	<_option value="japanese">Japanese</_option> 
+	<option value="greek">Greek 1-stroke</option>
+	<option value="timesg">Greek medium</option>
+	<option value="cyrillic">Cyrillic</option>		
+	<option value="japanese">Japanese</option> 
 
-	<_option value="astrology">Astrology</_option>
-	<_option value="mathlow">Math (lower)</_option>
-	<_option value="mathupp">Math (upper)</_option>
-	<_option value="markers">Markers</_option> 
-	<_option value="meteorology">Meteorology</_option>
-	<_option value="music">Music</_option>
-	<_option value="symbolic">Symbolic</_option>
+	<option value="astrology">Astrology</option>
+	<option value="mathlow">Math (lower)</option>
+	<option value="mathupp">Math (upper)</option>
+	<option value="markers">Markers</option> 
+	<option value="meteorology">Meteorology</option>
+	<option value="music">Music</option>
+	<option value="symbolic">Symbolic</option>
       </param>
-      <param name="face2" type="optiongroup" appearance="minimal"
-	     _gui-text="Secondary font ">
-	<_option value="scripts">Script 1-stroke</_option>
-	<_option value="cursive">Script 1-stroke (alt)</_option>
-	<_option value="scriptc">Script medium</_option>
+      <param name="face2" type="optiongroup" appearance="combo"
+	     gui-text="Secondary font ">
+	<option value="scripts">Script 1-stroke</option>
+	<option value="cursive">Script 1-stroke (alt)</option>
+	<option value="scriptc">Script medium</option>
 
-	<_option value="futural">Sans 1-stroke</_option>
-	<_option value="futuram">Sans bold</_option> 
+	<option value="futural">Sans 1-stroke</option>
+	<option value="futuram">Sans bold</option> 
 
-	<_option value="timesr">Serif medium</_option>
-	<_option value="timesi">Serif medium italic</_option>
-	<_option value="timesib">Serif bold italic</_option>
-	<_option value="timesrb">Serif bold</_option>
+	<option value="timesr">Serif medium</option>
+	<option value="timesi">Serif medium italic</option>
+	<option value="timesib">Serif bold italic</option>
+	<option value="timesrb">Serif bold</option>
 
-	<_option value="gothiceng">Gothic English</_option>
-	<_option value="gothicger">Gothic German</_option>
-	<_option value="gothicita">Gothic Italian</_option>	   
+	<option value="gothiceng">Gothic English</option>
+	<option value="gothicger">Gothic German</option>
+	<option value="gothicita">Gothic Italian</option>	   
 
-	<_option value="greek">Greek 1-stroke</_option>
-	<_option value="timesg">Greek medium</_option>
-	<_option value="cyrillic">Cyrillic</_option>		
-	<_option value="japanese">Japanese</_option> 
+	<option value="greek">Greek 1-stroke</option>
+	<option value="timesg">Greek medium</option>
+	<option value="cyrillic">Cyrillic</option>		
+	<option value="japanese">Japanese</option> 
 
-	<_option value="astrology">Astrology</_option>
-	<_option value="mathlow">Math (lower)</_option>
-	<_option value="mathupp">Math (upper)</_option>
-	<_option value="markers">Markers</_option> 
-	<_option value="meteorology">Meteorology</_option>
-	<_option value="music">Music</_option>
-	<_option value="symbolic">Symbolic</_option>
+	<option value="astrology">Astrology</option>
+	<option value="mathlow">Math (lower)</option>
+	<option value="mathupp">Math (upper)</option>
+	<option value="markers">Markers</option> 
+	<option value="meteorology">Meteorology</option>
+	<option value="music">Music</option>
+	<option value="symbolic">Symbolic</option>
       </param>
-      <param name="line01" type="string" _gui-text="Line  1">                              </param>
-      <param name="line02" type="string" _gui-text="Line  2">                              </param>
-      <param name="line03" type="string" _gui-text="Line  3">                              </param>
-      <param name="line04" type="string" _gui-text="Line  4">                              </param>
-      <param name="line05" type="string" _gui-text="Line  5">                              </param>
-      <param name="line06" type="string" _gui-text="Line  6">                              </param>
-      <param name="line07" type="string" _gui-text="Line  7">                              </param>
-      <param name="line08" type="string" _gui-text="Line  8">                              </param>
-      <param name="line09" type="string" _gui-text="Line  9">                              </param>
-      <param name="line10" type="string" _gui-text="Line 10">                              </param>
-      <param name="line11" type="string" _gui-text="Line 11">                              </param>
-      <param name="line12" type="string" _gui-text="Line 12">                              </param>
+      <param name="line01" type="string" gui-text="Line  1">                              </param>
+      <param name="line02" type="string" gui-text="Line  2">                              </param>
+      <param name="line03" type="string" gui-text="Line  3">                              </param>
+      <param name="line04" type="string" gui-text="Line  4">                              </param>
+      <param name="line05" type="string" gui-text="Line  5">                              </param>
+      <param name="line06" type="string" gui-text="Line  6">                              </param>
+      <param name="line07" type="string" gui-text="Line  7">                              </param>
+      <param name="line08" type="string" gui-text="Line  8">                              </param>
+      <param name="line09" type="string" gui-text="Line  9">                              </param>
+      <param name="line10" type="string" gui-text="Line 10">                              </param>
+      <param name="line11" type="string" gui-text="Line 11">                              </param>
+      <param name="line12" type="string" gui-text="Line 12">                              </param>
     </page>
-<page name="info" _gui-text="About...">
-<_param name="aboutpage" type="description" xml:space="preserve">
+<page name="info" gui-text="About...">
+<label xml:space="preserve">
 To render acrostic poetry, this extension uses the "Hershey"
 fonts for plotters.  These fonts are derived from NBS SP-424
 1976-04, "A contribution to computer typesetting techniques:
@@ -124,16 +123,16 @@ For additional information, please visit:
 
 
 
-</_param>
+</label>
 </page>
 </param>
   <effect needs-live-preview="false" needs-document="no">
     <object-type>all</object-type>
     <effects-menu>
-      <submenu _name="EggBot Contributed"/>
+      <submenu name="EggBot Contributed"/>
     </effects-menu>
   </effect>
   <script>
-    <command reldir="extensions" interpreter="python">eggbot_acrostic.py</command>
+    <command location="inx" interpreter="python">eggbot_acrostic.py</command>
   </script>
 </inkscape-extension>

--- a/extensions/eggbot_acrostic.inx
+++ b/extensions/eggbot_acrostic.inx
@@ -5,7 +5,7 @@
 <!--
   <dependency type="executable" location="extensions">hersheydata.py</dependency> -->
   <dependency type="executable" location="extensions">eggbot_acrostic.py</dependency>
-  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <dependency type="executable" location="extensions">inkex</dependency>
   <param name="tab" type="notebook">
     <page name="splash" gui-text="Render Text">
       <label>

--- a/extensions/eggbot_acrostic.py
+++ b/extensions/eggbot_acrostic.py
@@ -140,44 +140,44 @@ class AcrosticText( inkex.Effect ):
 	def __init__( self ):
 
 		inkex.Effect.__init__( self )
-		self.OptionParser.add_option( "--tab",	#NOTE: value is not used.
-			action="store", type="string", dest="tab", default="splash",
+		self.arg_parser.add_argument( "--tab",	#NOTE: value is not used.
+			type=str, dest="tab", default="splash",
 			help="The active tab when Apply was pressed" )
-		self.OptionParser.add_option( "--line01", action="store",
-			type="string", dest="line1", default="")
-		self.OptionParser.add_option( "--line02", action="store",
-			type="string", dest="line2", default="")
-		self.OptionParser.add_option( "--line03", action="store",
-			type="string", dest="line3", default="")
-		self.OptionParser.add_option( "--line04", action="store",
-			type="string", dest="line4", default="")
-		self.OptionParser.add_option( "--line05", action="store",
-			type="string", dest="line5", default="")
-		self.OptionParser.add_option( "--line06", action="store",
-			type="string", dest="line6", default="")
-		self.OptionParser.add_option( "--line07", action="store",
-			type="string", dest="line7", default="")
-		self.OptionParser.add_option( "--line08", action="store",
-			type="string", dest="line8", default="")
-		self.OptionParser.add_option( "--line09", action="store",
-			type="string", dest="line9", default="")
-		self.OptionParser.add_option( "--line10", action="store",
-			type="string", dest="line10", default="")
-		self.OptionParser.add_option( "--line11", action="store",
-			type="string", dest="line11", default="")
-		self.OptionParser.add_option( "--line12", action="store",
-			type="string", dest="line12", default="")
-		self.OptionParser.add_option( "--face1",
-			action="store", type="string", dest="face1", default="scriptc",
+		self.arg_parser.add_argument( "--line01",
+			type=str, dest="line1", default="")
+		self.arg_parser.add_argument( "--line02",
+			type=str, dest="line2", default="")
+		self.arg_parser.add_argument( "--line03",
+			type=str, dest="line3", default="")
+		self.arg_parser.add_argument( "--line04",
+			type=str, dest="line4", default="")
+		self.arg_parser.add_argument( "--line05",
+			type=str, dest="line5", default="")
+		self.arg_parser.add_argument( "--line06",
+			type=str, dest="line6", default="")
+		self.arg_parser.add_argument( "--line07",
+			type=str, dest="line7", default="")
+		self.arg_parser.add_argument( "--line08",
+			type=str, dest="line8", default="")
+		self.arg_parser.add_argument( "--line09",
+			type=str, dest="line9", default="")
+		self.arg_parser.add_argument( "--line10",
+			type=str, dest="line10", default="")
+		self.arg_parser.add_argument( "--line11",
+			type=str, dest="line11", default="")
+		self.arg_parser.add_argument( "--line12",
+			type=str, dest="line12", default="")
+		self.arg_parser.add_argument( "--face1",
+			type=str, dest="face1", default="scriptc",
 			help="Leading font typeface" )
-		self.OptionParser.add_option( "--face2", action="store",
-			type="string", dest="face2", default="scripts",
+		self.arg_parser.add_argument( "--face2",
+			type=str, dest="face2", default="scripts",
 			help="Secondary typeface" )
-		self.OptionParser.add_option( "--flip", action="store", type="inkbool",
+		self.arg_parser.add_argument( "--flip", type=inkex.Boolean,
 			dest="flip", default=False,
 			help="Flip the text for plotting with the egg's bottom at the egg motor" )
-		self.OptionParser.add_option( "--stretch",
-			action="store", type="inkbool", dest="stretch", default=True,
+		self.arg_parser.add_argument( "--stretch",
+			type=inkex.Boolean, dest="stretch", default=True,
 			help="Stretch the text horizontally to account for egg distortions" )
 
 	def effect( self ):

--- a/extensions/eggbot_acrostic.py
+++ b/extensions/eggbot_acrostic.py
@@ -30,6 +30,7 @@
 import hersheydata			# data file w/ Hershey font data
 import inkex
 import simplestyle
+import lxml.etree
 
 WIDTH     = 3200
 HEIGHT    = 800
@@ -81,7 +82,7 @@ def draw_svg_text(char, face, offset, vertoffset, parent):
 		pathString = pathString[i:] #portion after first move
 		trans = 'translate(' + str(midpoint) + ',' + str(vertoffset) + ')'
 		text_attribs = {'style':simplestyle.formatStyle(style), 'd':pathString, 'transform':trans}
-		inkex.etree.SubElement(parent, inkex.addNS('path','svg'), text_attribs)
+		lxml.etree.SubElement(parent, inkex.addNS('path','svg'), text_attribs)
 	return midpoint + int(splitString[1]) 	#new offset value
 
 def renderText( parent, w, y, text, typeface ):
@@ -132,7 +133,7 @@ def renderLine( parent, x, y, line, typeface1, typeface2 ):
 	line = line[1:]
 	if line == '':
 		return
-	g = inkex.etree.SubElement( parent, 'g' )
+	g = lxml.etree.SubElement( parent, 'g' )
 	renderText( g, x, y, line, typeface2 )
 
 class AcrosticText( inkex.Effect ):
@@ -253,12 +254,12 @@ class AcrosticText( inkex.Effect ):
 			attribs = { 'transform' : 'matrix(-%f,0,0,-%f,%d,%d)' % ( scale_x, scale_y, doc_width, doc_height ) }
 		else:
 			attribs = { 'transform' : 'scale(%f,%f)' % ( scale_x, scale_y ) }
-		container = inkex.etree.SubElement( self.document.getroot(), 'g', attribs )
+		container = lxml.etree.SubElement( self.document.getroot(), 'g', attribs )
 
 		# Finally, we render each line of text
 		for i in range( 0, len( lines ) ):
 			if lines[i] != '':
-				g = inkex.etree.SubElement( container, 'g' )
+				g = lxml.etree.SubElement( container, 'g' )
 				renderLine( g, x, y, lines[i], face1, face2 )
 			y += MAX_H + LINE_SKIP
 

--- a/extensions/eggbot_acrostic.py
+++ b/extensions/eggbot_acrostic.py
@@ -231,11 +231,11 @@ class AcrosticText( inkex.Effect ):
 
 		# Get the two type faces
 		name1 = self.options.face1
-		if map_our_names_to_hersheydata.has_key( name1 ):
+		if name1 in map_our_names_to_hersheydata:
 			name1 = map_our_names_to_hersheydata[name1]
 		face1 = eval( 'hersheydata.' + name1 )
 		name2 = self.options.face2
-		if map_our_names_to_hersheydata.has_key( name2 ):
+		if name2 in map_our_names_to_hersheydata:
 			name2 = map_our_names_to_hersheydata[name2]
 		face2 = eval( 'hersheydata.' + name2 )
 

--- a/extensions/eggbot_acrostic.py
+++ b/extensions/eggbot_acrostic.py
@@ -264,4 +264,4 @@ class AcrosticText( inkex.Effect ):
 
 if __name__ == '__main__':
 	e = AcrosticText()
-	e.affect()
+	e.run()

--- a/extensions/eggbot_acrostic.py
+++ b/extensions/eggbot_acrostic.py
@@ -29,7 +29,6 @@
 
 import hersheydata			# data file w/ Hershey font data
 import inkex
-import simplestyle
 import lxml.etree
 
 WIDTH     = 3200
@@ -81,7 +80,7 @@ def draw_svg_text(char, face, offset, vertoffset, parent):
 	if i >= 0:
 		pathString = pathString[i:] #portion after first move
 		trans = 'translate(' + str(midpoint) + ',' + str(vertoffset) + ')'
-		text_attribs = {'style':simplestyle.formatStyle(style), 'd':pathString, 'transform':trans}
+		text_attribs = {'style':str(inkex.Style(style)), 'd':pathString, 'transform':trans}
 		lxml.etree.SubElement(parent, inkex.addNS('path','svg'), text_attribs)
 	return midpoint + int(splitString[1]) 	#new offset value
 

--- a/extensions/eggbot_acrostic.py
+++ b/extensions/eggbot_acrostic.py
@@ -207,10 +207,10 @@ class AcrosticText( inkex.Effect ):
 		h = line_count * MAX_H + ( line_count - 1 ) * LINE_SKIP
 
 		svg = self.document.getroot()
-		doc_height = self.unittouu( svg.attrib['height'] )
+		doc_height = self.svg.unittouu( svg.attrib['height'] )
 		if doc_height <= 0:
 			doc_height = HEIGHT
-		doc_width = self.unittouu( svg.attrib['width'] )
+		doc_width = self.svg.unittouu( svg.attrib['width'] )
 		if doc_width <= 0:
 			doc_width = WIDTH
 

--- a/extensions/eggbot_acrostic.py
+++ b/extensions/eggbot_acrostic.py
@@ -27,7 +27,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-import hersheydata			# data file w/ Hershey font data
+#import hersheydata			# data file w/ Hershey font data
 import inkex
 import lxml.etree
 

--- a/extensions/eggbot_hatch.inx
+++ b/extensions/eggbot_hatch.inx
@@ -1,43 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-  <_name>Hatch fill</_name>
+  <name>Hatch fill</name>
   <id>command.eggbot.hatch.revb6</id>
   <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
   <dependency type="executable" location="extensions">eggbot_hatch.py</dependency>
   <dependency type="executable" location="extensions">inkex.py</dependency>
-  <dependency type="executable" location="extensions">simplepath.py</dependency>
-  <dependency type="executable" location="extensions">simpletransform.py</dependency>
-  <dependency type="executable" location="extensions">simplestyle.py</dependency>
-  <dependency type="executable" location="extensions">cubicsuperpath.py</dependency>
-  <dependency type="executable" location="extensions">cspsubdiv.py</dependency>
-  <dependency type="executable" location="extensions">bezmisc.py</dependency>
   <dependency type="executable" location="extensions">plot_utils.py</dependency>
 
 <param name="tab" type="notebook">
-  <page name="splash" _gui-text="Hatch Fill">
-  <_param name="Header" type="description" xml:space="preserve">
+  <page name="splash" gui-text="Hatch Fill">
+  <label xml:space="preserve">
 This extension fills each closed figure in your drawing
 with a path consisting of back and forth drawn "hatch" lines.
 If any objects are selected, then only those selected objects
 will be filled. 
 
 Hatched figures will be grouped with their fills.
-  </_param>
-  <param name="hatchSpacing" type="float" min="0" max="1000" _gui-text="   Hatch spacing (px)">5.0</param>
-  <param name="hatchAngle" type="float" min="-360" max="360" _gui-text="   Hatch angle (degrees)">45</param>
-  <param name="crossHatch" type="boolean" _gui-text="   Crosshatch?">false</param>
+  </label>
+  <param name="hatchSpacing" type="float" min="0" max="1000" gui-text="   Hatch spacing (px)">5.0</param>
+  <param name="hatchAngle" type="float" min="-360" max="360" gui-text="   Hatch angle (degrees)">45</param>
+  <param name="crossHatch" type="bool" gui-text="   Crosshatch?">false</param>
 
-  <param name="reducePenLifts" type="boolean" _gui-text="   Connect nearby ends?">true</param>
-  <param name="hatchScope" type="float" min="1.1" max="5.0" _gui-text="   Range of end connections (default: 3)">3.0</param>
-  <param name="holdBackHatchFromEdges" type="boolean" _gui-text="   Inset fill from edges?">true</param>
-  <param name="holdBackSteps" type="float" min="0.1" max="10.0" _gui-text="   Inset distance (px) (default: 1)">1.0</param>
-  <param name="tolerance" type="float" min="0.1" max="100" _gui-text="   Tolerance (default: 20)">20.0</param>
-  <param name="footer" type="description" xml:space="preserve">
-            (v2.1.0, December 8, 2017)</_param>
+  <param name="reducePenLifts" type="bool" gui-text="   Connect nearby ends?">true</param>
+  <param name="hatchScope" type="float" min="1.1" max="5.0" gui-text="   Range of end connections (default: 3)">3.0</param>
+  <param name="holdBackHatchFromEdges" type="bool" gui-text="   Inset fill from edges?">true</param>
+  <param name="holdBackSteps" type="float" min="0.1" max="10.0" gui-text="   Inset distance (px) (default: 1)">1.0</param>
+  <param name="tolerance" type="float" min="0.1" max="100" gui-text="   Tolerance (default: 20)">20.0</param>
+  <label xml:space="preserve">
+            (v2.1.0, December 8, 2017)</label>
 
   </page>
-  <page name="info" _gui-text="More info...">
-  <_param name="aboutpage" type="description" xml:space="preserve">
+  <page name="info" gui-text="More info...">
+  <label xml:space="preserve">
 Hatch spacing is the distance between hatch lines, 
 measured in units of screen pixels (px). Angles are in
 degrees from horizontal; for example 90 is vertical.
@@ -63,17 +57,17 @@ The hatches will be the same color and width
 as the original object.
 
 The Tolerance parameter affects how precisely
-the hatches try to fill the input paths.</_param>
+the hatches try to fill the input paths.</label>
  
   </page>
   </param>
   <effect needs-live-preview="true">
     <object-type>all</object-type>
     <effects-menu>
-      <submenu _name="EggBot"/>
+      <submenu name="EggBot"/>
     </effects-menu>
   </effect>
   <script>
-    <command reldir="extensions" interpreter="python">eggbot_hatch.py</command>
+    <command location="inx" interpreter="python">eggbot_hatch.py</command>
   </script>
 </inkscape-extension>

--- a/extensions/eggbot_hatch.inx
+++ b/extensions/eggbot_hatch.inx
@@ -4,7 +4,7 @@
   <id>command.eggbot.hatch.revb6</id>
   <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
   <dependency type="executable" location="extensions">eggbot_hatch.py</dependency>
-  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <dependency type="executable" location="extensions">inkex</dependency>
   <dependency type="executable" location="extensions">plot_utils.py</dependency>
 
 <param name="tab" type="notebook">

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -107,6 +107,7 @@ import inkex
 import simplepath
 from inkex.paths import Path
 import simpletransform
+from inkex.transforms import Transform
 
 import cubicsuperpath
 import cspsubdiv
@@ -684,7 +685,7 @@ class Eggbot_Hatch( inkex.Effect ):
 				if ( vinfo[2] != 0 ) and ( vinfo[3] != 0 ):
 					sx = self.docWidth / float( vinfo[2] )
 					sy = self.docHeight / float( vinfo[3] )
-					self.docTransform = simpletransform.parseTransform( 'scale(%f,%f)' % (sx, sy) )
+					self.docTransform = Transform( 'scale(%f,%f)' % (sx, sy) ).matrix
 
 	def addPathVertices( self, path, node=None, transform=None ):
 
@@ -820,7 +821,7 @@ class Eggbot_Hatch( inkex.Effect ):
 
 			# first apply the current matrix transform to this node's tranform
 			matNew = simpletransform.composeTransform( matCurrent,
-				simpletransform.parseTransform( node.get( "transform" ) ) )
+				Transform( node.get( "transform" ) ).matrix )
 				
 			if node.tag == inkex.addNS( 'g', 'svg' ) or node.tag == 'g':
 				self.recursivelyTraverseSvg( node, matNew, parent_visibility=v )
@@ -852,7 +853,7 @@ class Eggbot_Hatch( inkex.Effect ):
 					y = float( node.get( 'y', '0' ) )
 					# Note: the transform has already been applied
 					if ( x != 0 ) or ( y != 0 ):
-						matNew2 = composeTransform( matNew, parseTransform( 'translate(%f,%f)' % (x,y) ) )
+						matNew2 = composeTransform( matNew, Transform( 'translate(%f,%f)' % (x,y) ).matrix )
 					else:
 						matNew2 = matNew
 					v = node.get( 'visibility', v )

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -107,7 +107,7 @@ import inkex
 import simpletransform
 from inkex.transforms import Transform
 
-import cspsubdiv
+import inkex.bezier
 import bezmisc
 import math
 import plot_utils		# https://github.com/evil-mad/plotink
@@ -554,7 +554,7 @@ def subdivideCubicPath( sp, flat, i=1 ):
 	is approximately a straight line within a given tolerance
 	(the "smoothness" defined by [flat]).
 
-	This is a modified version of cspsubdiv.cspsubdiv() rewritten
+	This is a modified version of inkex.bezier.cspsubdiv() rewritten
 	to avoid recurrence.
 	"""
 
@@ -570,7 +570,7 @@ def subdivideCubicPath( sp, flat, i=1 ):
 
 			b = ( p0, p1, p2, p3 )
 
-			if cspsubdiv.maxdist( b ) > flat:
+			if inkex.bezier.maxdist( b ) > flat:
 				break
 
 			i += 1

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -711,7 +711,7 @@ class Eggbot_Hatch( inkex.Effect ):
 
 		# Apply any transformation
 		if transform is not None:
-			inkex.Path(p).transform( inkex.Transform(transform) ).to_arrays()
+			p = inkex.Path(p).transform( inkex.Transform(transform) ).to_arrays()
 
 		# Now traverse the simplified path
 		subpaths = []

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -775,7 +775,7 @@ class Eggbot_Hatch( inkex.Effect ):
 		# for path in self.paths:
 
 	def recursivelyTraverseSvg( self, aNodeList,
-		matCurrent=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+		matCurrent=((1.0, 0.0, 0.0), (0.0, 1.0, 0.0)),
 		parent_visibility='visible' ):
 		'''
 		Recursively walk the SVG document, building polygon vertex lists
@@ -820,8 +820,7 @@ class Eggbot_Hatch( inkex.Effect ):
 				pass
 
 			# first apply the current matrix transform to this node's tranform
-			matNew = simpletransform.composeTransform( matCurrent,
-				Transform( node.get( "transform" ) ).matrix )
+			matNew = ( Transform(matCurrent) * Transform( node.get( "transform" ) ) ).matrix
 				
 			if node.tag == inkex.addNS( 'g', 'svg' ) or node.tag == 'g':
 				self.recursivelyTraverseSvg( node, matNew, parent_visibility=v )
@@ -853,7 +852,7 @@ class Eggbot_Hatch( inkex.Effect ):
 					y = float( node.get( 'y', '0' ) )
 					# Note: the transform has already been applied
 					if ( x != 0 ) or ( y != 0 ):
-						matNew2 = composeTransform( matNew, Transform( 'translate(%f,%f)' % (x,y) ).matrix )
+						matNew2 = ( Transform(matNew) * Transform( 'translate(%f,%f)' % (x,y) ) ).matrix
 					else:
 						matNew2 = matNew
 					v = node.get( 'visibility', v )
@@ -873,7 +872,7 @@ class Eggbot_Hatch( inkex.Effect ):
 						# if self.options.crossHatch:
                          			# Now loop over our hatch lines looking for intersections
 						for h in self.grid:
-		                                	interstices( self, (h[0], h[1]), (h[2], h[3]), self.paths, self.hatches, self.options.holdBackHatchFromEdges, self.options.holdBackSteps )
+							interstices( self, (h[0], h[1]), (h[2], h[3]), self.paths, self.hatches, self.options.holdBackHatchFromEdges, self.options.holdBackSteps )
 					# if bHaveGrid
 					else:	
 						inkex.errormsg( ' Nothing to plot' )

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -1089,7 +1089,7 @@ class Eggbot_Hatch( inkex.Effect ):
 			elif node.tag == inkex.addNS( 'text', 'svg' ) or node.tag == 'text':
 				inkex.errormsg( 'Warning: unable to draw text, please convert it to a path first.' )
 				pass
-			elif not isinstance( node.tag, basestring ):
+			elif not isinstance( node.tag, str ):
 				pass
 			else:
 				inkex.errormsg( 'Warning: unable to hatch object <%s>, please convert it to a path first.' % node.tag )

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -104,8 +104,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 import inkex
-import simplepath
-from inkex.paths import Path
 import simpletransform
 from inkex.transforms import Transform
 
@@ -704,8 +702,8 @@ class Eggbot_Hatch( inkex.Effect ):
 		if ( not path ) or ( len( path ) == 0 ):
 			return
 
-		# parsePath() may raise an exception.  This is okay
-		sp = simplepath.parsePath( path )
+		# Path() may raise an exception.  This is okay
+		sp = inkex.Path( path ).to_arrays()
 		if ( not sp ) or ( len( sp ) == 0 ):
 			return
 
@@ -905,7 +903,7 @@ class Eggbot_Hatch( inkex.Effect ):
 				a.append( ['l', [0, h]] )
 				a.append( ['l', [-w, 0]] )
 				a.append( ['Z', []] )
-				self.addPathVertices( str(Path( a )), node, matNew )
+				self.addPathVertices( str(inkex.Path( a )), node, matNew )
 				# We now have a path we want to apply a (cross)hatch to
 				# Apply appropriate functions
 				bHaveGrid = self.makeHatchGrid( float( self.options.hatchAngle ),float( self.options.hatchSpacing ), True )
@@ -915,7 +913,7 @@ class Eggbot_Hatch( inkex.Effect ):
 						# if self.options.crossHatch:
                          			# Now loop over our hatch lines looking for intersections
 					for h in self.grid:
-		                               	interstices( self, (h[0], h[1]), (h[2], h[3]), self.paths, self.hatches, self.options.holdBackHatchFromEdges, self.options.holdBackSteps )
+						interstices( self, (h[0], h[1]), (h[2], h[3]), self.paths, self.hatches, self.options.holdBackHatchFromEdges, self.options.holdBackSteps )
 				# if bHaveGrid
 				else:	
 					inkex.errormsg( ' Nothing to plot' )
@@ -941,7 +939,7 @@ class Eggbot_Hatch( inkex.Effect ):
 				a = []
 				a.append( ['M', [x1, y1]] )
 				a.append( ['L', [x2, y2]] )
-				self.addPathVertices( str(Path( a )), node, matNew )
+				self.addPathVertices( str(inkex.Path( a )), node, matNew )
 				# We now have a path we want to apply a (cross)hatch to
 				# Apply appropriate functions
 				bHaveGrid = self.makeHatchGrid( float( self.options.hatchAngle ),float( self.options.hatchSpacing ), True )
@@ -951,7 +949,7 @@ class Eggbot_Hatch( inkex.Effect ):
 						# if self.options.crossHatch:
                          			# Now loop over our hatch lines looking for intersections
 					for h in self.grid:
-		                               	interstices( self, (h[0], h[1]), (h[2], h[3]), self.paths, self.hatches, self.options.holdBackHatchFromEdges, self.options.holdBackSteps )
+						interstices( self, (h[0], h[1]), (h[2], h[3]), self.paths, self.hatches, self.options.holdBackHatchFromEdges, self.options.holdBackSteps )
 				# if bHaveGrid
 				else:	
 					inkex.errormsg( ' Nothing to plot' )

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -545,40 +545,6 @@ def inverseTransform ( tran ):
 			[-tran[1][0]/D, tran[0][0]/D,
 			(tran[1][0]*tran[0][2] - tran[0][0]*tran[1][2])/D]]
 
-def subdivideCubicPath( sp, flat, i=1 ):
-
-	"""
-	Break up a bezier curve into smaller curves, each of which
-	is approximately a straight line within a given tolerance
-	(the "smoothness" defined by [flat]).
-
-	This is a modified version of inkex.bezier.cspsubdiv() rewritten
-	to avoid recurrence.
-	"""
-
-	while True:
-		while True:
-			if i >= len( sp ):
-				return
-
-			p0 = sp[i - 1][1]
-			p1 = sp[i - 1][2]
-			p2 = sp[i][0]
-			p3 = sp[i][1]
-
-			b = ( p0, p1, p2, p3 )
-
-			if inkex.bezier.maxdist( b ) > flat:
-				break
-
-			i += 1
-
-		one, two = inkex.bezier.beziersplitatt( b, 0.5 )
-		sp[i - 1][2] = one[1]
-		sp[i][0] = two[2]
-		p = [one[2], one[3], two[1]]
-		sp[i:1] = [p]
-
 
 def distanceSquared( P1, P2 ):
 

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -712,8 +712,8 @@ class Eggbot_Hatch( inkex.Effect ):
 			return
 
 		# Apply any transformation
-		if transform != None:
-			simpletransform.applyTransformToPath( transform, p )
+		if transform is not None:
+			inkex.Path(p).transform( inkex.Transform(transform) ).to_arrays()
 
 		# Now traverse the simplified path
 		subpaths = []

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -435,7 +435,7 @@ def interstices( self, P1, P2, paths, hatches, bHoldBackHatches, fHoldBackSteps 
 	i = 0
 	while i < ( len( dAndA ) - 1 ):
 	#for i in range( 0, len( sa ) - 1, 2 ):
-		if not hatches.has_key( dAndA[i][1] ):
+		if dAndA[i][1] not in hatches:
 			hatches[dAndA[i][1]] = []
 
 		x1 = P1[0] + dAndA[i][0] * ( P2[0] - P1[0] )
@@ -1275,7 +1275,7 @@ class Eggbot_Hatch( inkex.Effect ):
 		# To implement
 		for key in self.hatches:
 			direction = True
-			if self.transforms.has_key( key ):
+			if key in self.transforms:
 				transform = inverseTransform( self.transforms[key] )
 				# Determine the scaled stroke width for a hatch line
 				# We produce a line segment of unit length, transform

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -900,11 +900,11 @@ class Eggbot_Hatch( inkex.Effect ):
 				w = float( node.get( 'width', '0' ) )
 				h = float( node.get( 'height', '0' ) )
 				a = []
-				a.append( ['M ', [x, y]] )
-				a.append( [' l ', [w, 0]] )
-				a.append( [' l ', [0, h]] )
-				a.append( [' l ', [-w, 0]] )
-				a.append( [' Z', []] )
+				a.append( ['M', [x, y]] )
+				a.append( ['l', [w, 0]] )
+				a.append( ['l', [0, h]] )
+				a.append( ['l', [-w, 0]] )
+				a.append( ['Z', []] )
 				self.addPathVertices( str(Path( a )), node, matNew )
 				# We now have a path we want to apply a (cross)hatch to
 				# Apply appropriate functions
@@ -939,8 +939,8 @@ class Eggbot_Hatch( inkex.Effect ):
 				if ( not x1 ) or ( not y1 ) or ( not x2 ) or ( not y2 ):
 					pass
 				a = []
-				a.append( ['M ', [x1, y1]] )
-				a.append( [' L ', [x2, y2]] )
+				a.append( ['M', [x1, y1]] )
+				a.append( ['L', [x2, y2]] )
 				self.addPathVertices( str(Path( a )), node, matNew )
 				# We now have a path we want to apply a (cross)hatch to
 				# Apply appropriate functions
@@ -973,7 +973,7 @@ class Eggbot_Hatch( inkex.Effect ):
 					pass
 
 				pa = pl.split()
-				d = "".join( ["M " + pa[i] if i == 0 else " L " + pa[i] for i in range( 0, len( pa ) )] )
+				d = " ".join( ["M" + pa[i] if i == 0 else "L" + pa[i] for i in range( 0, len( pa ) )] )
 				self.addPathVertices( d, node, matNew )
 
 				# We now have a path we want to apply a (cross)hatch to
@@ -1006,8 +1006,8 @@ class Eggbot_Hatch( inkex.Effect ):
 					pass
 
 				pa = pl.split()
-				d = "".join( ["M " + pa[i] if i == 0 else " L " + pa[i] for i in range( 0, len( pa ) )] )
-				d += " Z"
+				d = " ".join( ["M" + pa[i] if i == 0 else "L" + pa[i] for i in range( 0, len( pa ) )] )
+				d += "Z"
 				self.addPathVertices( d, node, matNew )
 				# We now have a path we want to apply a (cross)hatch to
 				# Apply appropriate functions

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -107,7 +107,6 @@ import inkex
 import simpletransform
 from inkex.transforms import Transform
 
-import cubicsuperpath
 import cspsubdiv
 import bezmisc
 import math
@@ -708,7 +707,7 @@ class Eggbot_Hatch( inkex.Effect ):
 			return
 
 		# Get a cubic super duper path
-		p = cubicsuperpath.CubicSuperPath( sp )
+		p = inkex.Path( sp ).to_superpath()
 		if ( not p ) or ( len( p ) == 0 ):
 			return
 

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -105,6 +105,7 @@
 
 import inkex
 import simplepath
+from inkex.paths import Path
 import simpletransform
 
 import cubicsuperpath
@@ -904,7 +905,7 @@ class Eggbot_Hatch( inkex.Effect ):
 				a.append( [' l ', [0, h]] )
 				a.append( [' l ', [-w, 0]] )
 				a.append( [' Z', []] )
-				self.addPathVertices( simplepath.formatPath( a ), node, matNew )
+				self.addPathVertices( str(Path( a )), node, matNew )
 				# We now have a path we want to apply a (cross)hatch to
 				# Apply appropriate functions
 				bHaveGrid = self.makeHatchGrid( float( self.options.hatchAngle ),float( self.options.hatchSpacing ), True )
@@ -940,7 +941,7 @@ class Eggbot_Hatch( inkex.Effect ):
 				a = []
 				a.append( ['M ', [x1, y1]] )
 				a.append( [' L ', [x2, y2]] )
-				self.addPathVertices( simplepath.formatPath( a ), node, matNew )
+				self.addPathVertices( str(Path( a )), node, matNew )
 				# We now have a path we want to apply a (cross)hatch to
 				# Apply appropriate functions
 				bHaveGrid = self.makeHatchGrid( float( self.options.hatchAngle ),float( self.options.hatchSpacing ), True )

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -113,6 +113,8 @@ import bezmisc
 import math
 import plot_utils		# https://github.com/evil-mad/plotink
 
+import lxml.etree
+
 
 N_PAGE_WIDTH = 3200
 N_PAGE_HEIGHT = 800
@@ -1110,7 +1112,7 @@ class Eggbot_Hatch( inkex.Effect ):
 		#was: if not parent:
 		if parent is None:
 			parent = self.document.getroot()
-		g = inkex.etree.SubElement( parent, inkex.addNS( 'g', 'svg' ) )
+		g = lxml.etree.SubElement( parent, inkex.addNS( 'g', 'svg' ) )
 		# Move node to be a child of this new <g> element
 		g.append( node )
 
@@ -1141,7 +1143,7 @@ class Eggbot_Hatch( inkex.Effect ):
 			tran = node.get( 'transform' )
 			if ( tran != None ) and ( tran != '' ):
 				line_attribs['transform'] = tran
-			inkex.etree.SubElement( g, inkex.addNS( 'path', 'svg' ), line_attribs )
+			lxml.etree.SubElement( g, inkex.addNS( 'path', 'svg' ), line_attribs )
 
 	def makeHatchGrid( self, angle, spacing, init=True ):	# returns True if succeeds in making grid, else False
 

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -616,40 +616,40 @@ class Eggbot_Hatch( inkex.Effect ):
 		self.docTransform = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
 
 
-		self.OptionParser.add_option(
-			"--holdBackSteps", action="store", type="float",
+		self.arg_parser.add_argument(
+			"--holdBackSteps", type=float,
 			dest="holdBackSteps", default=3.0,
 			help="How far hatch strokes stay from boundary (steps)" )
-		self.OptionParser.add_option(
-			"--hatchScope", action="store", type="float",
+		self.arg_parser.add_argument(
+			"--hatchScope", type=float,
 			dest="hatchScope", default=3.0,
 			help="Radius searched for segments to join (units of hatch width)" )
-		self.OptionParser.add_option(
-			"--holdBackHatchFromEdges", action="store", dest="holdBackHatchFromEdges",
-			type="inkbool", default=True,
+		self.arg_parser.add_argument(
+			"--holdBackHatchFromEdges", dest="holdBackHatchFromEdges",
+			type=inkex.Boolean, default=True,
 			help="Stay away from edges, so no need for inset" )
-		self.OptionParser.add_option(
-			"--reducePenLifts", action="store", dest="reducePenLifts",
-			type="inkbool", default=True,
+		self.arg_parser.add_argument(
+			"--reducePenLifts", dest="reducePenLifts",
+			type=inkex.Boolean, default=True,
 			help="Reduce plotting time by joining some hatches" )
-		self.OptionParser.add_option(
-			"--crossHatch", action="store", dest="crossHatch",
-			type="inkbool", default=False,
+		self.arg_parser.add_argument(
+			"--crossHatch", dest="crossHatch",
+			type=inkex.Boolean, default=False,
 			help="Generate a cross hatch pattern" )
-		self.OptionParser.add_option(
-			"--hatchAngle", action="store", type="float",
+		self.arg_parser.add_argument(
+			"--hatchAngle", type=float,
 			dest="hatchAngle", default=90.0,
 			help="Angle of inclination for hatch lines" )
-		self.OptionParser.add_option(
-			"--hatchSpacing", action="store", type="float",
+		self.arg_parser.add_argument(
+			"--hatchSpacing", type=float,
 			dest="hatchSpacing", default=10.0,
 			help="Spacing between hatch lines" )
-		self.OptionParser.add_option(
-			"--tolerance", action="store", type="float",
+		self.arg_parser.add_argument(
+			"--tolerance", type=float,
 			dest="tolerance", default=20.0,
 			help="Allowed deviation from original paths" )
-		self.OptionParser.add_option( "--tab",	#NOTE: value is not used.
-			action="store", type="string", dest="tab", default="splash",
+		self.arg_parser.add_argument( "--tab",	#NOTE: value is not used.
+			type=str, dest="tab", default="splash",
 			help="The active tab when Apply was pressed" )
 
 	def getDocProps( self ):

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -782,7 +782,7 @@ class Eggbot_Hatch( inkex.Effect ):
 				pass
 
 			# first apply the current matrix transform to this node's tranform
-			matNew = ( Transform(matCurrent) * Transform( node.get( "transform" ) ) ).matrix
+			matNew = ( Transform(matCurrent) @ Transform( node.get( "transform" ) ) ).matrix
 				
 			if node.tag == inkex.addNS( 'g', 'svg' ) or node.tag == 'g':
 				self.recursivelyTraverseSvg( node, matNew, parent_visibility=v )
@@ -814,7 +814,7 @@ class Eggbot_Hatch( inkex.Effect ):
 					y = float( node.get( 'y', '0' ) )
 					# Note: the transform has already been applied
 					if ( x != 0 ) or ( y != 0 ):
-						matNew2 = ( Transform(matNew) * Transform( 'translate(%f,%f)' % (x,y) ) ).matrix
+						matNew2 = ( Transform(matNew) @ Transform( 'translate(%f,%f)' % (x,y) ) ).matrix
 					else:
 						matNew2 = matNew
 					v = node.get( 'visibility', v )

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -1797,4 +1797,4 @@ class Eggbot_Hatch( inkex.Effect ):
 if __name__ == '__main__':
 
 	e = Eggbot_Hatch()
-	e.affect()
+	e.run()

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -106,7 +106,7 @@
 import inkex
 import simplepath
 import simpletransform
-import simplestyle
+
 import cubicsuperpath
 import cspsubdiv
 import bezmisc
@@ -1139,7 +1139,7 @@ class Eggbot_Hatch( inkex.Effect ):
 			# if style != 'none':
 		finally:
 			style = { 'stroke': '%s' % stroke_color, 'fill': 'none', 'stroke-width': '%s' % stroke_width }
-			line_attribs = { 'style':simplestyle.formatStyle( style ), 'd': path }
+			line_attribs = { 'style':str(inkex.Style( style )), 'd': path }
 			tran = node.get( 'transform' )
 			if ( tran != None ) and ( tran != '' ):
 				line_attribs['transform'] = tran

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -107,7 +107,6 @@ import inkex
 from inkex.transforms import Transform
 
 import inkex.bezier
-import bezmisc
 import math
 import plot_utils		# https://github.com/evil-mad/plotink
 
@@ -574,7 +573,7 @@ def subdivideCubicPath( sp, flat, i=1 ):
 
 			i += 1
 
-		one, two = bezmisc.beziersplitatt( b, 0.5 )
+		one, two = inkex.bezier.beziersplitatt( b, 0.5 )
 		sp[i - 1][2] = one[1]
 		sp[i][0] = two[2]
 		p = [one[2], one[3], two[1]]

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -104,7 +104,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 import inkex
-import simpletransform
 from inkex.transforms import Transform
 
 import inkex.bezier
@@ -1279,10 +1278,10 @@ class Eggbot_Hatch( inkex.Effect ):
 				# We produce a line segment of unit length, transform
 				# its endpoints and then determine the length of the
 				# resulting line segment.
-				pt1 = [0, 0]
-				pt2 = [s, s]
-				simpletransform.applyTransformToPoint( transform, pt1 )
-				simpletransform.applyTransformToPoint( transform, pt2 )
+				pt1 = (0, 0)
+				pt2 = (s, s)
+				pt1 = inkex.Transform( transform ).apply_to_point( pt1 )
+				pt2 = inkex.Transform( transform ).apply_to_point( pt2 )
 				dx = pt2[0] - pt1[0]
 				dy = pt2[1] - pt1[1]
 				stroke_width = math.sqrt( dx * dx + dy * dy )
@@ -1319,8 +1318,8 @@ class Eggbot_Hatch( inkex.Effect ):
 					# after the fact (i.e., what's this tranform here for?).
 					# So, we compute the inverse transform and apply it here.
 					if transform != None:
-						simpletransform.applyTransformToPoint( transform, pt1 )
-						simpletransform.applyTransformToPoint( transform, pt2 )
+						pt1 = inkex.Transform( transform ).apply_to_point( pt1 )
+						pt2 = inkex.Transform( transform ).apply_to_point( pt2 )
 					# Now generate the path data for the <path>
 					if direction:
 						# Go this direction
@@ -1360,8 +1359,8 @@ class Eggbot_Hatch( inkex.Effect ):
 					# after the fact (i.e., what's this tranform here for?).
 					# So, we compute the inverse transform and apply it here.
 					if transform != None:
-						simpletransform.applyTransformToPoint( transform, pt1 )
-						simpletransform.applyTransformToPoint( transform, pt2 )
+						pt1 = inkex.Transform( transform ).apply_to_point( pt1 )
+						pt2 = inkex.Transform( transform ).apply_to_point( pt2 )
 
 					# Now generate the path data for the <path> 
 					# BUT we want to combine as many paths as possible to reduce pen lifts.

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -711,7 +711,9 @@ class Eggbot_Hatch( inkex.Effect ):
 
 		# Apply any transformation
 		if transform is not None:
-			p = inkex.Path(p).transform( inkex.Transform(transform) ).to_arrays()
+			p = p.transform( inkex.Transform(transform) )
+		# Subdivide into smaller path segments with given smoothness
+		inkex.bezier.cspsubdiv(p, float( self.options.tolerance / 100 ))
 
 		# Now traverse the simplified path
 		subpaths = []
@@ -724,7 +726,6 @@ class Eggbot_Hatch( inkex.Effect ):
 					# Keep the prior subpath: it appears to be a closed path
 					subpaths.append( subpath_vertices )
 			subpath_vertices = []
-			subdivideCubicPath( sp, float( self.options.tolerance / 100 ) )
 			for csp in sp:
 				# Add this vertex to the list of vertices
 				subpath_vertices.append( csp[1] )

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -1240,7 +1240,7 @@ class Eggbot_Hatch( inkex.Effect ):
 		if self.options.ids:
 			# Traverse the selected objects
 			for id in self.options.ids:
-				self.recursivelyTraverseSvg( [self.selected[id]], self.docTransform )
+				self.recursivelyTraverseSvg( [self.svg.selected[id]], self.docTransform )
 		else:
 			# Traverse the entire document
 			self.recursivelyTraverseSvg( self.document.getroot(), self.docTransform )

--- a/extensions/eggbot_hatch.py
+++ b/extensions/eggbot_hatch.py
@@ -321,6 +321,7 @@ def interstices( self, P1, P2, paths, hatches, bHoldBackHatches, fHoldBackSteps 
 							angleDifferenceRadians += 2 * math.pi
 						fSinOfJoinAngle = math.sin( angleDifferenceRadians )
 						fAbsSinOfJoinAngle = abs( fSinOfJoinAngle )
+						fPreliminaryLengthToBeRemovedFromPt = 0
 						if (fAbsSinOfJoinAngle != 0.0):								# Worrying about case of intersecting a segment parallel to the hatch
 							fPreliminaryLengthToBeRemovedFromPt = fHoldBackSteps / fAbsSinOfJoinAngle
 							bUnconditionallyExciseHatch = False
@@ -479,9 +480,8 @@ def interstices( self, P1, P2, paths, hatches, bHoldBackHatches, fHoldBackSteps 
 			fLengthToBeRemovedFromPt1 = dAndA[i][3]
 			fLengthToBeRemovedFromPt2 = dAndA[i+1][2]
 			
-			if ( ( fInitialHatchLength - ( fLengthToBeRemovedFromPt1 + fLengthToBeRemovedFromPt2 ) )		\
-					<=																						\
-					fMinAllowedHatchLength ):
+			if ( ( fInitialHatchLength - ( fLengthToBeRemovedFromPt1 + fLengthToBeRemovedFromPt2 ) )
+					<= fMinAllowedHatchLength ):
 				pass								# Just don't insert it into the hatch list
 			else:	# if (...too short...):
 				'''
@@ -662,7 +662,7 @@ class Eggbot_Hatch( inkex.Effect ):
 		self.docHeight = plot_utils.getLength( self, 'height', N_PAGE_HEIGHT )
 		self.docWidth = plot_utils.getLength( self, 'width', N_PAGE_WIDTH )
 		
-		if ( self.docHeight == None ) or ( self.docWidth == None ):
+		if (self.docHeight is None) or (self.docWidth is None):
 			return False
 		else:
 			return True
@@ -894,12 +894,11 @@ class Eggbot_Hatch( inkex.Effect ):
 					pass
 				w = float( node.get( 'width', '0' ) )
 				h = float( node.get( 'height', '0' ) )
-				a = []
-				a.append( ['M', [x, y]] )
-				a.append( ['l', [w, 0]] )
-				a.append( ['l', [0, h]] )
-				a.append( ['l', [-w, 0]] )
-				a.append( ['Z', []] )
+				a = [['M', [x, y]],
+					 ['l', [w, 0]],
+					 ['l', [0, h]],
+					 ['l', [-w, 0]],
+					 ['Z', []]]
 				self.addPathVertices( str(inkex.Path( a )), node, matNew )
 				# We now have a path we want to apply a (cross)hatch to
 				# Apply appropriate functions
@@ -933,9 +932,8 @@ class Eggbot_Hatch( inkex.Effect ):
 				y2 = float( node.get( 'y2' ) )
 				if ( not x1 ) or ( not y1 ) or ( not x2 ) or ( not y2 ):
 					pass
-				a = []
-				a.append( ['M', [x1, y1]] )
-				a.append( ['L', [x2, y2]] )
+				a = [['M', [x1, y1]],
+					 ['L', [x2, y2]]]
 				self.addPathVertices( str(inkex.Path( a )), node, matNew )
 				# We now have a path we want to apply a (cross)hatch to
 				# Apply appropriate functions
@@ -980,7 +978,7 @@ class Eggbot_Hatch( inkex.Effect ):
 						# if self.options.crossHatch:
                          			# Now loop over our hatch lines looking for intersections
 					for h in self.grid:
-		                               	interstices( self, (h[0], h[1]), (h[2], h[3]), self.paths, self.hatches, self.options.holdBackHatchFromEdges, self.options.holdBackSteps )
+						interstices( self, (h[0], h[1]), (h[2], h[3]), self.paths, self.hatches, self.options.holdBackHatchFromEdges, self.options.holdBackSteps )
 				# if bHaveGrid
 				else:	
 					inkex.errormsg( ' Nothing to plot' )
@@ -1013,7 +1011,7 @@ class Eggbot_Hatch( inkex.Effect ):
 						# if self.options.crossHatch:
                          			# Now loop over our hatch lines looking for intersections
 					for h in self.grid:
-		                               	interstices( self, (h[0], h[1]), (h[2], h[3]), self.paths, self.hatches, self.options.holdBackHatchFromEdges, self.options.holdBackSteps )
+						interstices( self, (h[0], h[1]), (h[2], h[3]), self.paths, self.hatches, self.options.holdBackHatchFromEdges, self.options.holdBackSteps )
 				else:	
 					inkex.errormsg( ' Nothing to plot' )
 
@@ -1066,7 +1064,7 @@ class Eggbot_Hatch( inkex.Effect ):
 						# if self.options.crossHatch:
                          			# Now loop over our hatch lines looking for intersections
 						for h in self.grid:
-		                               		interstices( self, (h[0], h[1]), (h[2], h[3]), self.paths, self.hatches, self.options.holdBackHatchFromEdges, self.options.holdBackSteps )
+							interstices( self, (h[0], h[1]), (h[2], h[3]), self.paths, self.hatches, self.options.holdBackHatchFromEdges, self.options.holdBackSteps )
 					else:	
 						inkex.errormsg( ' Nothing to plot' )
 
@@ -1119,7 +1117,7 @@ class Eggbot_Hatch( inkex.Effect ):
 		
 		try:
 			style = node.get('style')
-			if style != None:
+			if style is not None:
 				declarations = style.split(';')
 				for i,declaration in enumerate(declarations):
 					parts = declaration.split(':', 2)
@@ -1137,7 +1135,7 @@ class Eggbot_Hatch( inkex.Effect ):
 			style = { 'stroke': '%s' % stroke_color, 'fill': 'none', 'stroke-width': '%s' % stroke_width }
 			line_attribs = { 'style':str(inkex.Style( style )), 'd': path }
 			tran = node.get( 'transform' )
-			if ( tran != None ) and ( tran != '' ):
+			if (tran is not None) and (tran != ''):
 				line_attribs['transform'] = tran
 			lxml.etree.SubElement( g, inkex.addNS( 'path', 'svg' ), line_attribs )
 
@@ -1316,7 +1314,7 @@ class Eggbot_Hatch( inkex.Effect ):
 					# set in the path element seems a bit counterintuitive
 					# after the fact (i.e., what's this tranform here for?).
 					# So, we compute the inverse transform and apply it here.
-					if transform != None:
+					if transform is not None:
 						pt1 = inkex.Transform( transform ).apply_to_point( pt1 )
 						pt2 = inkex.Transform( transform ).apply_to_point( pt2 )
 					# Now generate the path data for the <path>
@@ -1357,7 +1355,7 @@ class Eggbot_Hatch( inkex.Effect ):
 					# set in the path element seems a bit counterintuitive
 					# after the fact (i.e., what's this tranform here for?).
 					# So, we compute the inverse transform and apply it here.
-					if transform != None:
+					if transform is not None:
 						pt1 = inkex.Transform( transform ).apply_to_point( pt1 )
 						pt2 = inkex.Transform( transform ).apply_to_point( pt2 )
 
@@ -1495,10 +1493,10 @@ class Eggbot_Hatch( inkex.Effect ):
 							# The solution is to hold in abeyance the actual plotting of the line,
 							# holding it available for shrinking if a curve is to be added.
 							# That is 
-							relativePositionOfLastPlottedLineWasHeldInAbeyance = {}
-							relativePositionOfLastPlottedLineWasHeldInAbeyance[0] = deltaX			# delta is from initial point
-							relativePositionOfLastPlottedLineWasHeldInAbeyance[1] = deltaY			# Will be printed after we know if it must be modified
-																									# to keep the ending join within bounds
+							relativePositionOfLastPlottedLineWasHeldInAbeyance = {
+								0: deltaX,  # delta is from initial point
+								1: deltaY   # Will be printed after we know if it must be modified to keep the ending join within bounds
+							}
 							ptLastPositionAbsolute[0] += deltaX
 							ptLastPositionAbsolute[1] += deltaY
 																		

--- a/extensions/eggbot_maze.inx
+++ b/extensions/eggbot_maze.inx
@@ -4,7 +4,7 @@
     <id>command.eggbot.contributed.eggmazing</id>
     <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
     <dependency type="executable" location="extensions">eggbot_maze.py</dependency>
-    <dependency type="executable" location="extensions">inkex.py</dependency>
+    <dependency type="executable" location="extensions">inkex</dependency>
     <param name="mazeSize" type="optiongroup" appearance="combo" gui-text="Maze dimensions (w x h):">
       <option value="SMALL">Small (32 x 6)</option>
       <option value="MEDIUM">Medium (64 x 12)</option>

--- a/extensions/eggbot_maze.inx
+++ b/extensions/eggbot_maze.inx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <_name>Eggmazing</_name>
+    <name>Eggmazing</name>
     <id>command.eggbot.contributed.eggmazing</id>
     <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
     <dependency type="executable" location="extensions">eggbot_maze.py</dependency>
     <dependency type="executable" location="extensions">inkex.py</dependency>
-    <param name="mazeSize" type="optiongroup" appearance="" _gui-text="Maze dimensions (w x h):">
+    <param name="mazeSize" type="optiongroup" appearance="combo" gui-text="Maze dimensions (w x h):">
       <option value="SMALL">Small (32 x 6)</option>
       <option value="MEDIUM">Medium (64 x 12)</option>
       <option value="LARGE">Large (96 x 18)</option>
@@ -15,12 +15,12 @@
     <effect needs-live-preview="false">
       <object-type>all</object-type>
       <effects-menu>
-	<submenu _name="EggBot Contributed"/>
+	<submenu name="EggBot Contributed"/>
       </effects-menu>
     </effect>
 
     <script>
-      <command reldir="extensions" interpreter="python">eggbot_maze.py</command>
+      <command location="inx" interpreter="python">eggbot_maze.py</command>
     </script>
 
 </inkscape-extension>

--- a/extensions/eggbot_maze.py
+++ b/extensions/eggbot_maze.py
@@ -668,4 +668,4 @@ class Maze( inkex.Effect ):
 
 if __name__ == '__main__':
 	e = Maze()
-	e.affect()
+	e.run()

--- a/extensions/eggbot_maze.py
+++ b/extensions/eggbot_maze.py
@@ -606,6 +606,7 @@ class Maze( inkex.Effect ):
 			dy = 1
 
 		tracing = False
+		segment = None
 		for x in range( 0, self.w ):
 
 			if self.is_wall( x, y, wall ):
@@ -649,7 +650,7 @@ class Maze( inkex.Effect ):
 
 		tracing = False
 		for y in range( y_start, y_finis, dy ):
-			assert 0 <= y and y < self.h, "y (%d) is out of range" % y
+			assert 0 <= y < self.h, "y (%d) is out of range" % y
 			if self.is_wall( x, y, wall ):
 				if not tracing:
 					# Starting a new segment

--- a/extensions/eggbot_maze.py
+++ b/extensions/eggbot_maze.py
@@ -53,7 +53,6 @@ import array
 import random
 import math
 import inkex
-import simplestyle
 
 import lxml.etree
 

--- a/extensions/eggbot_maze.py
+++ b/extensions/eggbot_maze.py
@@ -120,15 +120,15 @@ class Maze( inkex.Effect ):
 
 		inkex.Effect.__init__( self )
 
-		self.OptionParser.add_option(
-			"--tab", action="store", type="string",
+		self.arg_parser.add_argument(
+			"--tab", type=str,
 			dest="tab", default="controls",
 			help="The active tab when Apply was pressed" )
-		self.OptionParser.add_option(
-			"--mazeSize", action="store", type="string", dest="mazeSize",
+		self.arg_parser.add_argument(
+			"--mazeSize", type=str, dest="mazeSize",
 			default="MEDIUM", help="Difficulty of maze to build" )
-		#self.OptionParser.add_option(
-		#	"--hpp", action="store", type="inkbool", dest="hpp", default=False,
+		#self.arg_parser.add_argument(
+		#	"--hpp", type=inkex.Boolean, dest="hpp", default=False,
 		#	help="Use a faster plotting technique that requires much better plotting precision" )
 		#self.hpp = self.options.hpp
 

--- a/extensions/eggbot_maze.py
+++ b/extensions/eggbot_maze.py
@@ -386,7 +386,7 @@ class Maze( inkex.Effect ):
 		node.set( 'height', '800' )
 
 		# The following end up being ignored by Inkscape....
-		node = self.getNamedView()
+		node = self.svg.namedview
 		node.set( 'showborder',  'false' )
 		node.set( inkex.addNS( 'cx', u'inkscape' ), '1600' )
 		node.set( inkex.addNS( 'cy', u'inkscape' ), '500' )

--- a/extensions/eggbot_maze.py
+++ b/extensions/eggbot_maze.py
@@ -82,14 +82,14 @@ def draw_SVG_path( pts, c, t, parent ):
 	else:
 		return
 	style = { 'stroke':c, 'stroke-width':str( t ), 'fill':'none' }
-	line_attribs = { 'style':simplestyle.formatStyle( style ),'d':d }
+	line_attribs = { 'style':str(inkex.Style( style )),'d':d }
 	lxml.etree.SubElement( parent, inkex.addNS( 'path','svg' ), line_attribs )
 
 # Add a SVG rect element to the document
 
 def draw_SVG_rect( x, y, w, h, c, t, fill, parent ):
 	style = { 'stroke':c, 'stroke-width':str( t ), 'fill':fill }
-	rect_attribs = { 'style':simplestyle.formatStyle( style ),
+	rect_attribs = { 'style':str(inkex.Style( style )),
 					  'x':str( x ), 'y':str( y ),
 					  'width':str( w ), 'height':str( h ) }
 	lxml.etree.SubElement( parent, inkex.addNS( 'rect', 'svg' ),

--- a/extensions/eggbot_maze.py
+++ b/extensions/eggbot_maze.py
@@ -55,6 +55,8 @@ import math
 import inkex
 import simplestyle
 
+import lxml.etree
+
 # Initialize the psuedo random number generator
 random.seed()
 
@@ -81,7 +83,7 @@ def draw_SVG_path( pts, c, t, parent ):
 		return
 	style = { 'stroke':c, 'stroke-width':str( t ), 'fill':'none' }
 	line_attribs = { 'style':simplestyle.formatStyle( style ),'d':d }
-	inkex.etree.SubElement( parent, inkex.addNS( 'path','svg' ), line_attribs )
+	lxml.etree.SubElement( parent, inkex.addNS( 'path','svg' ), line_attribs )
 
 # Add a SVG rect element to the document
 
@@ -90,7 +92,7 @@ def draw_SVG_rect( x, y, w, h, c, t, fill, parent ):
 	rect_attribs = { 'style':simplestyle.formatStyle( style ),
 					  'x':str( x ), 'y':str( y ),
 					  'width':str( w ), 'height':str( h ) }
-	inkex.etree.SubElement( parent, inkex.addNS( 'rect', 'svg' ),
+	lxml.etree.SubElement( parent, inkex.addNS( 'rect', 'svg' ),
 							rect_attribs )
 
 class Maze( inkex.Effect ):
@@ -309,7 +311,7 @@ class Maze( inkex.Effect ):
 			inkex.addNS( 'label', 'inkscape' ) : '1 - Maze',
 			inkex.addNS( 'groupmode', 'inkscape' ) : 'layer',
 			'transform' : t }
-		maze_layer = inkex.etree.SubElement( self.document.getroot(), 'g', attribs )
+		maze_layer = lxml.etree.SubElement( self.document.getroot(), 'g', attribs )
 		draw_SVG_path( self.path, "#000000", float( 1 / self.scale ), maze_layer )
 
 		# Now draw the solution in red in layer "2 - Solution"
@@ -318,7 +320,7 @@ class Maze( inkex.Effect ):
 			inkex.addNS( 'label', 'inkscape' ) : '2 - Solution',
 			inkex.addNS( 'groupmode', 'inkscape' ) : 'layer',
 			'transform' : t }
-		maze_layer = inkex.etree.SubElement( self.document.getroot(), 'g', attribs )
+		maze_layer = lxml.etree.SubElement( self.document.getroot(), 'g', attribs )
 
 		# Mark the starting cell
 

--- a/extensions/eggbot_pptb.inx
+++ b/extensions/eggbot_pptb.inx
@@ -4,7 +4,7 @@
     <id>command.eggbot.contributed.eggbot_pptb</id>
     <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
     <dependency type="executable" location="extensions">eggbot_pptb.py</dependency>
-    <dependency type="executable" location="extensions">inkex</dependency>       <dependency type="executable" location="extensions">simplestyle.py</dependency>
+    <dependency type="executable" location="extensions">inkex</dependency>
     <label xml:space="preserve">
 This extension is intended for use after
 running the Inkscape "Trace Bitmap" tool

--- a/extensions/eggbot_pptb.inx
+++ b/extensions/eggbot_pptb.inx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <_name>Post process trace bitmap</_name>
+    <name>Post process trace bitmap</name>
     <id>command.eggbot.contributed.eggbot_pptb</id>
     <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
     <dependency type="executable" location="extensions">eggbot_pptb.py</dependency>
     <dependency type="executable" location="extensions">inkex.py</dependency>       <dependency type="executable" location="extensions">simplestyle.py</dependency>
-    <_param name="Header" type="description" xml:space="preserve">
+    <label xml:space="preserve">
 This extension is intended for use after
 running the Inkscape "Trace Bitmap" tool
 of the "Path" menu
@@ -25,21 +25,21 @@ Running this extension:
     fills within each traced regions
 4. Can optionally outline the traced
     regions
-    </_param>
+    </label>
 
-    <param name="removeImage" type="boolean" _gui-text="Remove original bitmap image?">true</param>
-    <param name="fillRegions" type="boolean" _gui-text="Fill each traced region with color?">true</param>
-    <param name="outlineRegions" type="boolean" _gui-text="Outline each traced region?">true</param>
+    <param name="removeImage" type="bool" gui-text="Remove original bitmap image?">true</param>
+    <param name="fillRegions" type="bool" gui-text="Fill each traced region with color?">true</param>
+    <param name="outlineRegions" type="bool" gui-text="Outline each traced region?">true</param>
 
     <effect needs-live-preview="false">
       <object-type>all</object-type>
       <effects-menu>
-	<submenu _name="EggBot Contributed"/>
+	<submenu name="EggBot Contributed"/>
       </effects-menu>
     </effect>
 
     <script>
-      <command reldir="extensions" interpreter="python">eggbot_pptb.py</command>
+      <command location="inx" interpreter="python">eggbot_pptb.py</command>
     </script>
 
 </inkscape-extension>

--- a/extensions/eggbot_pptb.inx
+++ b/extensions/eggbot_pptb.inx
@@ -4,7 +4,7 @@
     <id>command.eggbot.contributed.eggbot_pptb</id>
     <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
     <dependency type="executable" location="extensions">eggbot_pptb.py</dependency>
-    <dependency type="executable" location="extensions">inkex.py</dependency>       <dependency type="executable" location="extensions">simplestyle.py</dependency>
+    <dependency type="executable" location="extensions">inkex</dependency>       <dependency type="executable" location="extensions">simplestyle.py</dependency>
     <label xml:space="preserve">
 This extension is intended for use after
 running the Inkscape "Trace Bitmap" tool

--- a/extensions/eggbot_pptb.py
+++ b/extensions/eggbot_pptb.py
@@ -27,7 +27,6 @@
 
 import inkex
 import gettext
-import simplestyle
 
 import lxml.etree
 
@@ -59,7 +58,7 @@ class EggBot_PostProcessTraceBitmap( inkex.Effect ):
 			stroke, fill, color = ( 'none', 'none', 'unknown' )
 
 			# Get the paths style attribute
-			style = simplestyle.parseStyle( path.get( 'style', '' ) )
+			style = dict(inkex.Style.parse_str( path.get( 'style', '' ) ))
 			# Obtain the fill color from the path's style attribute
 			if 'fill' in style:
 				color = style['fill']

--- a/extensions/eggbot_pptb.py
+++ b/extensions/eggbot_pptb.py
@@ -75,7 +75,7 @@ class EggBot_PostProcessTraceBitmap( inkex.Effect ):
 			style['stroke'] = stroke
 
 			# And change the style attribute for the path
-			path.set( 'style', simplestyle.formatStyle( style ) )
+			path.set( 'style', str(inkex.Style( style ) ))
 
 			# Create a group <g> element under the document root
 			layer = lxml.etree.SubElement( root, inkex.addNS( 'g', 'svg' ) )

--- a/extensions/eggbot_pptb.py
+++ b/extensions/eggbot_pptb.py
@@ -112,4 +112,3 @@ class EggBot_PostProcessTraceBitmap( inkex.Effect ):
 if __name__ == '__main__':
 	e = EggBot_PostProcessTraceBitmap()
 	e.run()
-	e.affect()

--- a/extensions/eggbot_pptb.py
+++ b/extensions/eggbot_pptb.py
@@ -29,6 +29,8 @@ import inkex
 import gettext
 import simplestyle
 
+import lxml.etree
+
 class EggBot_PostProcessTraceBitmap( inkex.Effect ):
 
 	def __init__(self):
@@ -76,7 +78,7 @@ class EggBot_PostProcessTraceBitmap( inkex.Effect ):
 			path.set( 'style', simplestyle.formatStyle( style ) )
 
 			# Create a group <g> element under the document root
-			layer = inkex.etree.SubElement( root, inkex.addNS( 'g', 'svg' ) )
+			layer = lxml.etree.SubElement( root, inkex.addNS( 'g', 'svg' ) )
 
 			# Add Inkscape layer attributes to this new group
 			count += 1

--- a/extensions/eggbot_pptb.py
+++ b/extensions/eggbot_pptb.py
@@ -110,4 +110,5 @@ class EggBot_PostProcessTraceBitmap( inkex.Effect ):
 
 if __name__ == '__main__':
 	e = EggBot_PostProcessTraceBitmap()
+	e.run()
 	e.affect()

--- a/extensions/eggbot_pptb.py
+++ b/extensions/eggbot_pptb.py
@@ -33,17 +33,17 @@ class EggBot_PostProcessTraceBitmap( inkex.Effect ):
 
 	def __init__(self):
 		inkex.Effect.__init__( self )
-		self.OptionParser.add_option(
-			"--outlineRegions", action="store", dest="outlineRegions",
-			type="inkbool", default=True,
+		self.arg_parser.add_argument(
+			"--outlineRegions", dest="outlineRegions",
+			type=inkex.Boolean, default=True,
 			help="Outline the regions with a stroked line of the same color as the region itself" )
-		self.OptionParser.add_option(
-			"--fillRegions", action="store", dest="fillRegions",
-			type="inkbool", default=True,
+		self.arg_parser.add_argument(
+			"--fillRegions", dest="fillRegions",
+			type=inkex.Boolean, default=True,
 			help="Fill regions with color" )
-		self.OptionParser.add_option(
-			"--removeImage", action="store", dest="removeImage",
-			type="inkbool", default=True,
+		self.arg_parser.add_argument(
+			"--removeImage", dest="removeImage",
+			type=inkex.Boolean, default=True,
 			help="Remove the traced bitmap image from the drawing" )
 
 	def effect(self):

--- a/extensions/eggbot_presethatch.inx
+++ b/extensions/eggbot_presethatch.inx
@@ -3,7 +3,7 @@
    <name>Preset hatch for fills</name>
    <id>command.evilmadscience.hatch.eggbot</id>
        <dependency type="executable" location="extensions">eggbot_presethatch.py</dependency>
-       <dependency type="executable" location="extensions">inkex.py</dependency>
+       <dependency type="executable" location="extensions">inkex</dependency>
        <label xml:space="preserve">
 This extension applies a set of eggbot-friendly
 default presets to the live path effect called

--- a/extensions/eggbot_presethatch.inx
+++ b/extensions/eggbot_presethatch.inx
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-   <_name>Preset hatch for fills</_name>
+   <name>Preset hatch for fills</name>
    <id>command.evilmadscience.hatch.eggbot</id>
        <dependency type="executable" location="extensions">eggbot_presethatch.py</dependency>
        <dependency type="executable" location="extensions">inkex.py</dependency>
-       <_param name="title" type="description" xml:space="preserve">
+       <label xml:space="preserve">
 This extension applies a set of eggbot-friendly
 default presets to the live path effect called
 "Hatch (rough)."
@@ -17,14 +17,14 @@ the "Edit paths by node" tool to change the
 frequency, direction, and/or bending of the 
 hatching, by dragging the diamond control 
 points.
-</_param>
+</label>
    <effect>
                <object-type>path</object-type>
                 <effects-menu>
-      <submenu _name="EggBot"/>
+      <submenu name="EggBot"/>
                 </effects-menu>
    </effect>
    <script>
-       <command reldir="extensions" interpreter="python">eggbot_presethatch.py</command>
+       <command location="inx" interpreter="python">eggbot_presethatch.py</command>
    </script>
 </inkscape-extension>

--- a/extensions/eggbot_presethatch.py
+++ b/extensions/eggbot_presethatch.py
@@ -21,7 +21,7 @@ import inkex
 class PresetHatch(inkex.Effect):
 	def __init__(self):
 		inkex.Effect.__init__(self)
-		self.OptionParser.add_option("--title")
+		self.arg_parser.add_argument("--title")
 	def effect(self):
 		self.svgDefRead = False;
 		self.svg = self.document.getroot()

--- a/extensions/eggbot_presethatch.py
+++ b/extensions/eggbot_presethatch.py
@@ -49,4 +49,4 @@ class PresetHatch(inkex.Effect):
 					node.set( 'fat_output', 'false' )
 
 e = PresetHatch()
-e.affect()
+e.run()

--- a/extensions/eggbot_presethatch.py
+++ b/extensions/eggbot_presethatch.py
@@ -23,7 +23,7 @@ class PresetHatch(inkex.Effect):
 		inkex.Effect.__init__(self)
 		self.arg_parser.add_argument("--title")
 	def effect(self):
-		self.svgDefRead = False;
+		self.svgDefRead = False
 		self.svg = self.document.getroot()
 		self.recursiveDefDataScan(self.svg)
 

--- a/extensions/eggbot_reorder.inx
+++ b/extensions/eggbot_reorder.inx
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-  <_name>Reorder Paths for Speed</_name>
+  <name>Reorder Paths for Speed</name>
   <id>command.evilmadscience.eggbot_reorder2.eggbot</id>
   <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
   <dependency type="executable" location="extensions">eggbot_reorder.py</dependency>
   <dependency type="executable" location="extensions">inkex.py</dependency>
   <!-- Written by Matthew Beckler for the Egg-Bot project. Email questions and comments to matthew at mbeckler dot org -->
 
-	  <_param name="Header" type="description" xml:space="preserve">
+	  <label xml:space="preserve">
  This extension will perform simple optimizations 
  of selected paths. It will try to change the 
  order of plotting so as to reduce the amount
@@ -26,23 +26,23 @@
  experimental, and is only provided in case you 
  may find it useful. Be sure to save a copy of 
  your document before running this routine.
-            </_param>
+            </label>
 
   <!--
-  <param name="reverse" type="boolean" _gui-text="Allow paths to be reversed*">false</param>
-  <param name="wrap" type="boolean" _gui-text="Allow wrap-around egg axis*">false</param>
+  <param name="reverse" type="bool" gui-text="Allow paths to be reversed*">false</param>
+  <param name="wrap" type="bool" gui-text="Allow wrap-around egg axis*">false</param>
 
-	  <_param name="nyet" type="description" xml:space="preserve">
+	  <label xml:space="preserve">
   *Option not yet implemented.
-            </_param>
+            </label>
 -->
-  <effect needs-live-preview="false" needs-document="no">
+  <effect needs-live-preview="false" needs-document="false">
     <object-type>all</object-type>
     <effects-menu>
-        <submenu _name="EggBot"/>
+        <submenu name="EggBot"/>
     </effects-menu>
   </effect>
   <script>
-    <command reldir="extensions" interpreter="python">eggbot_reorder.py</command>
+    <command location="inx" interpreter="python">eggbot_reorder.py</command>
   </script>
 </inkscape-extension>

--- a/extensions/eggbot_reorder.inx
+++ b/extensions/eggbot_reorder.inx
@@ -4,7 +4,7 @@
   <id>command.evilmadscience.eggbot_reorder2.eggbot</id>
   <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
   <dependency type="executable" location="extensions">eggbot_reorder.py</dependency>
-  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <dependency type="executable" location="extensions">inkex</dependency>
   <!-- Written by Matthew Beckler for the Egg-Bot project. Email questions and comments to matthew at mbeckler dot org -->
 
 	  <label xml:space="preserve">

--- a/extensions/eggbot_reorder.py
+++ b/extensions/eggbot_reorder.py
@@ -127,7 +127,7 @@ class EggBotReorderPaths( inkex.Effect ):
 		"""This is the main entry point"""
 
 		# based partially on the restack.py extension
-		if len( self.selected ) > 0:
+		if len( self.svg.selected ) > 0:
 			svg = self.document.getroot()
 
 			# TODO check for non-path elements?
@@ -141,7 +141,7 @@ class EggBotReorderPaths( inkex.Effect ):
 			# 2. Some magic with xpath? (would this limit us to specific node types?)
 
 			objlist = []
-			for id, node in self.selected.iteritems():
+			for id, node in self.svg.selected.iteritems():
 				transform = node.get( 'transform' )
 				if transform:
 					transform = simpletransform.parseTransform( transform )
@@ -154,8 +154,8 @@ class EggBotReorderPaths( inkex.Effect ):
 
 			for id in sort_order:
 				# There's some good magic here, that you can use an
-				# object id to index into self.selected. Brilliant!
-				self.current_layer.append( self.selected[id] )
+				# object id to index into self.svg.selected. Brilliant!
+				self.current_layer.append( self.svg.selected[id] )
 
 			#fid.close()
 

--- a/extensions/eggbot_reorder.py
+++ b/extensions/eggbot_reorder.py
@@ -167,4 +167,4 @@ class EggBotReorderPaths( inkex.Effect ):
 
 
 e = EggBotReorderPaths()
-e.affect()
+e.run()

--- a/extensions/eggbot_reorder.py
+++ b/extensions/eggbot_reorder.py
@@ -24,7 +24,7 @@ import inkex
 import math
 import random
 import simplepath
-import simpletransform
+from inkex.transforms import Transform
 import sys
 
 def dist( x0, y0, x1, y1 ):
@@ -144,7 +144,7 @@ class EggBotReorderPaths( inkex.Effect ):
 			for id, node in self.svg.selected.iteritems():
 				transform = node.get( 'transform' )
 				if transform:
-					transform = simpletransform.parseTransform( transform )
+					transform = Transform( transform ).matrix
 
 				item = ( id, self.get_start_end( node, transform ) )
 				objlist.append( item )

--- a/extensions/eggbot_reorder.py
+++ b/extensions/eggbot_reorder.py
@@ -105,7 +105,7 @@ class EggBotReorderPaths( inkex.Effect ):
 	def get_start_end( self, node, transform ):
 		"""Given a node, return the start and end points"""
 		d = node.get( 'd' )
-		sp = simplepath.parsePath( d )
+		sp = inkex.Path( d ).to_arrays()
 
 		# simplepath converts coordinates to absolute and cleans them up, but
 		# these are still some big assumptions here, are they always valid? TODO

--- a/extensions/eggbot_reorder.py
+++ b/extensions/eggbot_reorder.py
@@ -63,6 +63,7 @@ def find_ordering_naive( objlist ):
 	# for the previous end point, iterate over each remaining path and pick the closest starting point
 	while len( objlist ) > 0:
 		min_distance = 100000000 # TODO put something else here better?
+		min_path = None
 		for path in objlist:
 			# instead of having a prevX, prevY, we just look at the last item in sort_list
 			this_distance = dist( sort_list[-1][1][2], sort_list[-1][1][3], path[1][0], path[1][1] )
@@ -127,7 +128,7 @@ class EggBotReorderPaths( inkex.Effect ):
 
 		# based partially on the restack.py extension
 		if len( self.svg.selected ) > 0:
-			svg = self.document.getroot()
+			svg = self.document.getroot()  # TODO: Can be removed?
 
 			# TODO check for non-path elements?
 			# TODO it seems like the order of selection is not consistent

--- a/extensions/eggbot_reorder.py
+++ b/extensions/eggbot_reorder.py
@@ -97,9 +97,9 @@ def conv( x, y, trans_matrix=None ):
 class EggBotReorderPaths( inkex.Effect ):
 	def __init__( self ):
 		inkex.Effect.__init__( self )
-# 		self.OptionParser.add_option( '-r', '--reverse', action='store', type="inkbool",
+# 		self.arg_parser.add_argument( '-r', '--reverse', type=inkex.Boolean,
 # 			dest="reverse", default=True, help="Enable 'reverse path direction' optimizations" )
-# 		self.OptionParser.add_option( '-w', '--wrap', action='store', type="inkbool",
+# 		self.arg_parser.add_argument( '-w', '--wrap', type=inkex.Boolean,
 # 				dest="wrap", default=True, help="Enable 'wrap egg axis' optimizations" )
 
 	def get_start_end( self, node, transform ):

--- a/extensions/eggbot_reorder.py
+++ b/extensions/eggbot_reorder.py
@@ -23,7 +23,6 @@ import gettext
 import inkex
 import math
 import random
-import simplepath
 from inkex.transforms import Transform
 import sys
 

--- a/extensions/eggbot_reorder.py
+++ b/extensions/eggbot_reorder.py
@@ -84,7 +84,7 @@ def find_ordering_naive( objlist ):
 def conv( x, y, trans_matrix=None ):
 	"""
 	not used currently, but can be used to apply a translation matrix to an (x, y) pair
-	I'm sure there is a better way to do this using simpletransform or it's ilk
+	I'm sure there is a better way to do this using inkex.Transform or it's ilk
 	"""
 
 	if trans_matrix:

--- a/extensions/eggbot_scanlinux.py
+++ b/extensions/eggbot_scanlinux.py
@@ -30,10 +30,10 @@ def findPorts():
 		yield os.path.join( DEV_TREE , device )
 
 if __name__ == '__main__':
-	print "Looking for EiBotBoards"
+	print("Looking for EiBotBoards")
 	for port in findEiBotBoards():
-		print "  ", port
+		print("  ", port)
 
-	print "Looking for COM ports"
+	print("Looking for COM ports")
 	for port in findPorts():
-		print "  ", port
+		print("  ", port)

--- a/extensions/eggbot_sineandlace.inx
+++ b/extensions/eggbot_sineandlace.inx
@@ -1,45 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-  <_name>Sine and Lace</_name>
+  <name>Sine and Lace</name>
   <id>command.experiment.sineandlace</id>
   <dependency type="executable" location="extensions">eggbot_sineandlace.py</dependency>
   <dependency type="executable" location="extensions">inkex.py</dependency>
 
 <param name="tab" type="notebook">
-  <page name="splash" _gui-text="Sine and Lace">
+  <page name="splash" gui-text="Sine and Lace">
     <param name="nWidth" type="int" min="1" max="10000"
-	 _gui-text="Width (pixels)">3200</param>
+	 gui-text="Width (pixels)">3200</param>
 
     <param name="nHeight" type="int" min="1" max="10000"
-	 _gui-text="Height (pixels)">100</param>
+	 gui-text="Height (pixels)">100</param>
 
     <param name="fCycles" type="float" min="0.0001" max="10000" precision="5"
-	 _gui-text="Number of cycles (periods)">10</param>
+	 gui-text="Number of cycles (periods)">10</param>
 
     <param name="nrN" type="int" min="-100" max="100"
-	 _gui-text="Start angle at 2 pi ( n / m ); n = ">0</param>
+	 gui-text="Start angle at 2 pi ( n / m ); n = ">0</param>
 
     <param name="nrM" type="int" min="-100" max="100"
-	 _gui-text="Start angle at 2 pi ( n / m ); m = ">0</param>
+	 gui-text="Start angle at 2 pi ( n / m ); m = ">0</param>
 
     <param name="fRecess" type="float" min="0" max="100" precision="5"
-	 _gui-text="Recede from envelope by percentage">2</param>
+	 gui-text="Recede from envelope by percentage">2</param>
 
     <param name="nSamples" type="int" min="2" max="100000"
-	 _gui-text="Number of sample points">1000</param>
+	 gui-text="Number of sample points">1000</param>
 
     <param name="nOffsetX" type="int" min="-10000" max="10000"
-	 _gui-text="Starting x coordinate (pixels)">0</param>
+	 gui-text="Starting x coordinate (pixels)">0</param>
 
     <param name="nOffsetY" type="int" min="-10000" max="10000"
-	 _gui-text="Starting y coordinate (pixels)">500</param>
+	 gui-text="Starting y coordinate (pixels)">500</param>
 
-    <param name="bLace" type="boolean" _gui-text="Lace">true</param>
+    <param name="bLace" type="bool" gui-text="Lace">true</param>
 
-    <param name="bSpline" type="boolean" _gui-text="Spline">false</param>
+    <param name="bSpline" type="bool" gui-text="Spline">false</param>
   </page>
-  <page name="info" _gui-text="About...">
-    <_param name="aboutpage" type="description" xml:space="preserve">
+  <page name="info" gui-text="About...">
+    <label xml:space="preserve">
 This extension renders sinusoidal and "lace"
 patterns whose period is a specified multiple
 of the document width or any specified width.
@@ -54,16 +54,17 @@ Thing #24594.
 Sine and Lace v0.9
 Dan Newman (dan newman @ mtbaldy us)
 12 June 2012
-</_param>
+</label>
   </page>
 </param>
 
   <effect>
+    <object-type>all</object-type>
     <effects-menu>
-      <submenu _name="EggBot Contributed"/>
+      <submenu name="EggBot Contributed"/>
     </effects-menu>
   </effect>
   <script>
-    <command reldir="extensions" interpreter="python">eggbot_sineandlace.py</command>
+    <command location="inx" interpreter="python">eggbot_sineandlace.py</command>
   </script>
 </inkscape-extension>

--- a/extensions/eggbot_sineandlace.inx
+++ b/extensions/eggbot_sineandlace.inx
@@ -3,7 +3,7 @@
   <name>Sine and Lace</name>
   <id>command.experiment.sineandlace</id>
   <dependency type="executable" location="extensions">eggbot_sineandlace.py</dependency>
-  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <dependency type="executable" location="extensions">inkex</dependency>
 
 <param name="tab" type="notebook">
   <page name="splash" gui-text="Sine and Lace">

--- a/extensions/eggbot_sineandlace.py
+++ b/extensions/eggbot_sineandlace.py
@@ -28,7 +28,6 @@
 
 import inkex
 import simplepath
-import simplestyle
 from math import *
 
 import lxml.etree
@@ -326,9 +325,9 @@ class SpiroSine( inkex.Effect ):
 
 		if self.options.ids:
 			if len( self.options.ids ) == 2:
-				attr = self.selected[self.options.ids[0]].attrib
-				desc1 = self.selected[self.options.ids[0]].get( inkex.addNS( 'desc', self.nsPrefix ) )
-				desc2 = self.selected[self.options.ids[1]].get( inkex.addNS( 'desc', self.nsPrefix ) )
+				attr = self.svg.selected[self.options.ids[0]].attrib
+				desc1 = self.svg.selected[self.options.ids[0]].get( inkex.addNS( 'desc', self.nsPrefix ) )
+				desc2 = self.svg.selected[self.options.ids[1]].get( inkex.addNS( 'desc', self.nsPrefix ) )
 				if ( not desc1 ) or ( not desc2 ):
 					inkex.errormsg( 'Selected objects do not smell right' )
 					return

--- a/extensions/eggbot_sineandlace.py
+++ b/extensions/eggbot_sineandlace.py
@@ -256,53 +256,53 @@ class SpiroSine( inkex.Effect ):
 
 		inkex.Effect.__init__(self)
 
-		self.OptionParser.add_option( "--tab",	#NOTE: value is not used.
-			action="store", type="string",
+		self.arg_parser.add_argument( "--tab",	#NOTE: value is not used.
+			type=str,
 			dest="tab", default="splash",
 			help="The active tab when Apply was pressed" )
 
-		self.OptionParser.add_option('--fCycles', dest='fCycles',
-			type='float', default=float( 10 ), action='store',
+		self.arg_parser.add_argument('--fCycles', dest='fCycles',
+			type=float, default=float( 10 ),
 			help='Number of cycles (periods)' )
 
-		self.OptionParser.add_option('--nrN', dest='nrN',
-			type='int', default=int( 0 ), action='store',
+		self.arg_parser.add_argument('--nrN', dest='nrN',
+			type=int, default=int( 0 ),
 			help='Start x at 2 * pi * n / m' )
 
-		self.OptionParser.add_option('--nrM', dest='nrM',
-			type='int', default=int( 0 ), action='store',
+		self.arg_parser.add_argument('--nrM', dest='nrM',
+			type=int, default=int( 0 ),
 			help='Start x at 2 * pi * n / m' )
 
-		self.OptionParser.add_option('--fRecess', dest='fRecess',
-			type='float', default=float( 2 ), action='store',
+		self.arg_parser.add_argument('--fRecess', dest='fRecess',
+			type=float, default=float( 2 ),
 			help='Recede from envelope by factor' )
 
-		self.OptionParser.add_option("--nSamples", dest="nSamples",
-			type="int", default=float( 50 ), action="store",
+		self.arg_parser.add_argument("--nSamples", dest="nSamples",
+			type=int, default=float( 50 ),
 			help="Number of points to sample" )
 
-		self.OptionParser.add_option("--nWidth", dest="nWidth",
-			type="int", default=int( 3200 ), action="store",
+		self.arg_parser.add_argument("--nWidth", dest="nWidth",
+			type=int, default=int( 3200 ),
 			help="Width in pixels" )
 
-		self.OptionParser.add_option("--nHeight", dest="nHeight",
-			type="int", default=int( 100 ), action="store",
+		self.arg_parser.add_argument("--nHeight", dest="nHeight",
+			type=int, default=int( 100 ),
 			help="Height in pixels" )
 
-		self.OptionParser.add_option("--nOffsetX", dest="nOffsetX",
-			type="int", default=int( 0 ), action="store",
+		self.arg_parser.add_argument("--nOffsetX", dest="nOffsetX",
+			type=int, default=int( 0 ),
 			help="Starting x coordinate (pixels)" )
 
-		self.OptionParser.add_option("--nOffsetY", dest="nOffsetY",
-			type="int", default=int( 400 ), action="store",
+		self.arg_parser.add_argument("--nOffsetY", dest="nOffsetY",
+			type=int, default=int( 400 ),
 			help="Starting y coordinate (pixels)" )
 
-		self.OptionParser.add_option('--bLace', dest='bLace',
-			type='inkbool', default=False, action='store',
+		self.arg_parser.add_argument('--bLace', dest='bLace',
+			type=inkex.Boolean, default=False,
 			help='Lace' )
 
-		self.OptionParser.add_option('--bSpline', dest='bSpline',
-			type='inkbool', default=True, action='store',
+		self.arg_parser.add_argument('--bSpline', dest='bSpline',
+			type=inkex.Boolean, default=True,
 			help='Spline' )
 
 		self.recess = float( 0.95 )

--- a/extensions/eggbot_sineandlace.py
+++ b/extensions/eggbot_sineandlace.py
@@ -31,6 +31,8 @@ import simplepath
 import simplestyle
 from math import *
 
+import lxml.etree
+
 VERSION = 1
 
 def parseDesc( str ):
@@ -360,7 +362,7 @@ class SpiroSine( inkex.Effect ):
 			'style': simplestyle.formatStyle( style ),
 			'd': simplepath.formatPath( path_data ),
 			inkex.addNS( 'desc', self.nsPrefix ): path_desc }
-		newpath = inkex.etree.SubElement( self.document.getroot(),
+		newpath = lxml.etree.SubElement( self.document.getroot(),
 			inkex.addNS( 'path', 'svg '), path_attrs, nsmap=inkex.NSS )
 
 if __name__ == '__main__':

--- a/extensions/eggbot_sineandlace.py
+++ b/extensions/eggbot_sineandlace.py
@@ -27,7 +27,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 import inkex
-import simplepath
+from inkex.paths import Path
 from math import *
 
 import lxml.etree
@@ -359,7 +359,7 @@ class SpiroSine( inkex.Effect ):
 		style = { 'stroke': 'black', 'stroke-width': '1', 'fill': 'none' }
 		path_attrs = {
 			'style': str(inkex.Style( style )),
-			'd': simplepath.formatPath( path_data ),
+			'd': str(Path( path_data )),
 			inkex.addNS( 'desc', self.nsPrefix ): path_desc }
 		newpath = lxml.etree.SubElement( self.document.getroot(),
 			inkex.addNS( 'path', 'svg '), path_attrs, nsmap=inkex.NSS )

--- a/extensions/eggbot_sineandlace.py
+++ b/extensions/eggbot_sineandlace.py
@@ -27,7 +27,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 import inkex
-from inkex.paths import Path
 from math import *
 
 import lxml.etree
@@ -359,7 +358,7 @@ class SpiroSine( inkex.Effect ):
 		style = { 'stroke': 'black', 'stroke-width': '1', 'fill': 'none' }
 		path_attrs = {
 			'style': str(inkex.Style( style )),
-			'd': str(Path( path_data )),
+			'd': str(inkex.Path( path_data )),
 			inkex.addNS( 'desc', self.nsPrefix ): path_desc }
 		newpath = lxml.etree.SubElement( self.document.getroot(),
 			inkex.addNS( 'path', 'svg'), path_attrs, nsmap=inkex.NSS )

--- a/extensions/eggbot_sineandlace.py
+++ b/extensions/eggbot_sineandlace.py
@@ -53,7 +53,7 @@ def formatDesc( d ):
 
 	return ';'.join( [ atr + ':' + str( val ) for atr,val in d.iteritems() ] )
 
-def drawSine( cycles=8, rn=0, rm=0, nPoints=50, offset=[0, 0],
+def drawSine( cycles=8, rn=0, rm=0, nPoints=50, offset=(0, 0),
 	height=200, width=3200, rescale=0.98, bound1='', bound2='', fun='sine', spline=True ):
 
 	'''
@@ -145,7 +145,6 @@ def drawSine( cycles=8, rn=0, rm=0, nPoints=50, offset=[0, 0],
 	yOffset = float( offset[1] )
 
 	# Each cycle is 2pi
-	n, m = int( 0 ), int( 0 )
 	r = 2 * pi * float( cycles )
 	if ( int( rm ) == 0 ) or ( int( rn ) == 0 ):
 		xMin = float( 0 )
@@ -201,8 +200,7 @@ def drawSine( cycles=8, rn=0, rm=0, nPoints=50, offset=[0, 0],
 	dy1 = dYdXs( float( 0 ) )
 
 	# Starting point in the path is ( x, sin(x) )
-	pathData = []
-	pathData.append(['M', [ x1 , y1 ] ] )
+	pathData = [['M', [x1, y1]]]
 
 	for i in range( 1, nPoints ):
 

--- a/extensions/eggbot_sineandlace.py
+++ b/extensions/eggbot_sineandlace.py
@@ -359,7 +359,7 @@ class SpiroSine( inkex.Effect ):
 
 		style = { 'stroke': 'black', 'stroke-width': '1', 'fill': 'none' }
 		path_attrs = {
-			'style': simplestyle.formatStyle( style ),
+			'style': str(inkex.Style( style )),
 			'd': simplepath.formatPath( path_data ),
 			inkex.addNS( 'desc', self.nsPrefix ): path_desc }
 		newpath = lxml.etree.SubElement( self.document.getroot(),

--- a/extensions/eggbot_sineandlace.py
+++ b/extensions/eggbot_sineandlace.py
@@ -203,7 +203,7 @@ def drawSine( cycles=8, rn=0, rm=0, nPoints=50, offset=[0, 0],
 
 	# Starting point in the path is ( x, sin(x) )
 	pathData = []
-	pathData.append(['M ', [ x1 , y1 ] ] )
+	pathData.append(['M', [ x1 , y1 ] ] )
 
 	for i in range( 1, nPoints ):
 
@@ -227,15 +227,15 @@ def drawSine( cycles=8, rn=0, rm=0, nPoints=50, offset=[0, 0],
 
 		# Add another segment to the plot
 		if spline:
-			pathData.append( [' C ',
+			pathData.append( ['C',
 					 [ x1 + ( dx1 * xThird ),
 					   y1 + ( dy1 * xThird ),
 					   x2 - ( dx2 * xThird ),
 					   y2 - ( dy2 * xThird ),
 					   x2, y2 ] ] )
 		else:
-			pathData.append([' L ', [ x1, y1 ] ] )
-			pathData.append([' L ', [ x2, y2 ] ] )
+			pathData.append(['L', [ x1, y1 ] ] )
+			pathData.append(['L', [ x2, y2 ] ] )
 		x1  = x2
 		y1  = y2
 		dx1 = dx2
@@ -362,7 +362,7 @@ class SpiroSine( inkex.Effect ):
 			'd': str(Path( path_data )),
 			inkex.addNS( 'desc', self.nsPrefix ): path_desc }
 		newpath = lxml.etree.SubElement( self.document.getroot(),
-			inkex.addNS( 'path', 'svg '), path_attrs, nsmap=inkex.NSS )
+			inkex.addNS( 'path', 'svg'), path_attrs, nsmap=inkex.NSS )
 
 if __name__ == '__main__':
 

--- a/extensions/eggbot_sineandlace.py
+++ b/extensions/eggbot_sineandlace.py
@@ -366,4 +366,4 @@ class SpiroSine( inkex.Effect ):
 if __name__ == '__main__':
 
 	e = SpiroSine()
-	e.affect()
+	e.run()

--- a/extensions/eggbot_spiraltext.inx
+++ b/extensions/eggbot_spiraltext.inx
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-  <_name>Spiral Wrapped Text</_name>
+  <name>Spiral Wrapped Text</name>
   <id>command.eggbot.contributed.eggbot_spiraltext101</id>
   <dependency type="executable" location="extensions">hersheydata.py</dependency>
-  <dependency type="executable" location="extensions">simplestyle.py</dependency>
   <dependency type="executable" location="extensions">eggbot_spiraltext.py</dependency>
   <dependency type="executable" location="extensions">inkex.py</dependency>
   <param name="tab" type="notebook">
-    <page name="splash" _gui-text="Render Text">
-      <_param name="stuff" type="description">
+    <page name="splash" gui-text="Render Text">
+      <label>
 This extension renders passages of text as a single, long line
 of text, tilted slightly so that it spirals as it wraps around
 your egg.
@@ -16,20 +15,20 @@ your egg.
 Specify the number of times the text should wrap. This value
 need not be a whole number.  The text will then be scaled so
 as to have the length (number of times to wrap) x 3200 pixels.
-</_param>
-      <param name="wrap" type="float" min="1" max="100" _gui-text="Number of times to wrap ">8.5</param>
-      <param name="stretch" type="boolean" _gui-text="Stretch the text horizontally to account for the egg's geometry? ">true</param>
-      <param name="flip" type="boolean" _gui-text="Plot with the egg's bottom at the egg motor? ">false</param>
-      <param name="text" type="string" _gui-text="Text ">How do you drop an egg 2 meters without it breaking? Drop it from 3 meters: it won't break for the first 2!  *   If a rooster laid an egg at the peak of a roof, which side would it roll down? Neither side: roosters don't lay eggs!  *  What's the best day to eat eggs? Fry day  *  What happens when you tickle eggs? They crack up!  *  What sport are eggs good at? Running!  * What kind of jokes do eggs tell? Egg yolks  *  What's an egg's favorite robot? The EggBot!</param>
+</label>
+      <param name="wrap" type="float" min="1" max="100" gui-text="Number of times to wrap ">8.5</param>
+      <param name="stretch" type="bool" gui-text="Stretch the text horizontally to account for the egg's geometry? ">true</param>
+      <param name="flip" type="bool" gui-text="Plot with the egg's bottom at the egg motor? ">false</param>
+      <param name="text" type="string" gui-text="Text ">How do you drop an egg 2 meters without it breaking? Drop it from 3 meters: it won't break for the first 2!  *   If a rooster laid an egg at the peak of a roof, which side would it roll down? Neither side: roosters don't lay eggs!  *  What's the best day to eat eggs? Fry day  *  What happens when you tickle eggs? They crack up!  *  What sport are eggs good at? Running!  * What kind of jokes do eggs tell? Egg yolks  *  What's an egg's favorite robot? The EggBot!</param>
 <!-- OMELET (2 servings): For a firm omelet, beat 2 eggs with a fork until blended.  Beat in 2 tablespoons cream or milk, 1/4 teaspoon salt, and a pinch of white pepper or paprika.  In a non-stick skillet, melt 3/4 tablespoons butter.  When hot, add the egg mixture and cook over low heat.  With a spatula, lift the edges and, by tilting the skillet, allow the uncooked custard to run underneath the omelet.  When the omelet is cooked to an even consistency, fold over and serve.  <times><i&>Bon appetit!</i></times> -->
-      <param name="fontfamily" type="optiongroup" appearance="minimal" _gui-text="Starting font ">
-	<_option value="sans">Sans</_option>
-	<_option value="times">Times</_option>
-	<_option value="script">Script</_option>
+      <param name="fontfamily" type="optiongroup" appearance="combo" gui-text="Starting font ">
+	<option value="sans">Sans</option>
+	<option value="times">Times</option>
+	<option value="script">Script</option>
       </param>
     </page>
-    <page name="markup" _gui-text="Markup">
-      <_param name="aboutpage" type="description" xml:space="preserve">
+    <page name="markup" gui-text="Markup">
+      <label xml:space="preserve">
 Simple&#160;markup&#160;may&#160;be&#160;used&#160;to&#160;switch&#160;between&#160;type&#160;faces&#160;(fonts)
 as well as to select bold, italic and emphasized type faces.
 
@@ -47,10 +46,10 @@ Special characters:
   &lt;  --  Enter " &amp;lt; " in your text
   &gt;  --  Enter " &amp;gt; " in your text
   &amp;  --  Enter " &amp;amp; " in your text 
-</_param>
+</label>
     </page>
-    <page name="fonts1" _gui-text="Text Fonts">
-      <_param name="aboutpage1" type="description" xml:space="preserve">
+    <page name="fonts1" gui-text="Text Fonts">
+      <label xml:space="preserve">
 In addition to the sans, times and script type families, other text-oriented
 type faces are available.  For these faces, use of the &lt;b&gt;, &lt;em&gt; and
 &lt;i&gt; markups have no effect and are ignored.
@@ -70,10 +69,10 @@ For a complete list of EMS fonts, refer to the "Font face" list in the Render/He
 
 
 
-</_param>
+</label>
 </page>
-    <page name="fonts2" _gui-text="Symbol Fonts">
-      <_param name="aboutpage1" type="description" xml:space="preserve">
+    <page name="fonts2" gui-text="Symbol Fonts">
+      <label xml:space="preserve">
 In addition to type faces for text, several type faces of symbols
 are also available.  When these type faces are used, the &lt;b&gt;,
 &lt;em&gt; and &lt;i&gt; markups have no effect and are ignored.
@@ -91,10 +90,10 @@ are also available.  When these type faces are used, the &lt;b&gt;,
 
 
 
-</_param>
+</label>
 </page>
-<page name="info" _gui-text="About...">
-<_param name="aboutpage3" type="description" xml:space="preserve">
+<page name="info" gui-text="About...">
+<label xml:space="preserve">
 This extension renders a passage of text tilted at an angle
 so as to wrap around an egg in a spiral.  To render the text,
 the "Hershey" fonts for plotters is used.  These fonts are
@@ -108,16 +107,16 @@ extension under the "Render" category of Extensions.
 For additional information, please visit:
 
   www.evilmadscientist.com/go/hershey
-</_param>
+</label>
 </page>
 </param>
-  <effect needs-live-preview="true" needs-document="no">
+  <effect needs-live-preview="true" needs-document="false">
     <object-type>all</object-type>
     <effects-menu>
-      <submenu _name="EggBot Contributed"/>
+      <submenu name="EggBot Contributed"/>
     </effects-menu>
   </effect>
   <script>
-    <command reldir="extensions" interpreter="python">eggbot_spiraltext.py</command>
+    <command location="inx" interpreter="python">eggbot_spiraltext.py</command>
   </script>
 </inkscape-extension>

--- a/extensions/eggbot_spiraltext.inx
+++ b/extensions/eggbot_spiraltext.inx
@@ -4,7 +4,7 @@
   <id>command.eggbot.contributed.eggbot_spiraltext101</id>
   <dependency type="executable" location="extensions">hersheydata.py</dependency>
   <dependency type="executable" location="extensions">eggbot_spiraltext.py</dependency>
-  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <dependency type="executable" location="extensions">inkex</dependency>
   <param name="tab" type="notebook">
     <page name="splash" gui-text="Render Text">
       <label>

--- a/extensions/eggbot_spiraltext.py
+++ b/extensions/eggbot_spiraltext.py
@@ -421,7 +421,7 @@ class SpiralText( inkex.Effect ):
 
 		# And the angular tilt will be arcsine( height / (3200 * fWrap) )
 		svg = self.document.getroot()
-		height = float( self.unittouu( svg.attrib['height'] ) ) - h * scale_y
+		height = float( self.svg.unittouu( svg.attrib['height'] ) ) - h * scale_y
 		angle = ( float( 180 ) / math.pi ) * \
 			math.asin( height / float( 3200 * self.options.wrap ) )
 

--- a/extensions/eggbot_spiraltext.py
+++ b/extensions/eggbot_spiraltext.py
@@ -135,7 +135,7 @@ def renderText( parent, markup ):
 	spacing = 3  # spacing between letters
 
 	for Face, Text in markup:
-		if map_our_names_to_hersheydata.has_key(Face):
+		if Face in map_our_names_to_hersheydata:
 			Face = map_our_names_to_hersheydata[Face]
 		font = eval('hersheydata.' + Face)
 		letterVals = [ord(q) - 32 for q in Text]
@@ -203,7 +203,7 @@ def pickFace( family, bold=False, italics=False, emphasis=False ):
 	if italics:
 		i = '1'
 
-	if family_to_font.has_key( family + b + i ):
+	if ( family + b + i ) in family_to_font:
 		return family_to_font[family + b + i]
 
 	return family
@@ -245,7 +245,7 @@ def processMarkup( text, family='sans' ):
 			j = text.find( ';', i+1 )
 			if ( j != -1 ):
 				eref = text[i:j+1]
-				if entity_refs.has_key(eref):
+				if eref in entity_refs:
 					outstr += entity_refs[eref]
 					i = j + 1
 				else:
@@ -325,7 +325,7 @@ def processMarkup( text, family='sans' ):
 						tag = normalize_possible_EMS_string( tag )
 					if (
 							( tag not in generic_families )
-							and ( not map_our_names_to_hersheydata.has_key( tag ) )
+							and ( tag not in map_our_names_to_hersheydata )
 							and ( not bValidEMSName )
 						):
 						if close:

--- a/extensions/eggbot_spiraltext.py
+++ b/extensions/eggbot_spiraltext.py
@@ -213,7 +213,7 @@ def processMarkup( text, family='sans' ):
 	# By default we assume 'sans'
 	if ( family is None ) or ( family == ''):
 		family = 'sans'
-	family_default = family
+	default_family = family
 	face_stack = [ family ]
 
 	# Bold and italics off

--- a/extensions/eggbot_spiraltext.py
+++ b/extensions/eggbot_spiraltext.py
@@ -76,6 +76,8 @@ import simplestyle
 import math
 import string
 
+import lxml.etree
+
 # Mapping table to map the names used here to the corresponding
 # names used in hersheydata.py.  This helps prevent end users from
 # being impacted by a name change in hersheydata.py.  This can also
@@ -121,13 +123,13 @@ def draw_svg_text(char, face, offset, vertoffset, parent):
 		pathString = pathString[i:] #portion after first move
 		trans = 'translate(' + str(midpoint) + ',' + str(vertoffset) + ')'
 		text_attribs = {'style':simplestyle.formatStyle(style), 'd':pathString, 'transform':trans}
-		inkex.etree.SubElement(parent, inkex.addNS('path','svg'), text_attribs)
+		lxml.etree.SubElement(parent, inkex.addNS('path','svg'), text_attribs)
 	return midpoint + float(splitString[1]) 	#new offset value
 
 def renderText( parent, markup ):
 	# Embed text in group to make manipulation easier:
 	g_attribs = {inkex.addNS('label','inkscape'):'Hershey Text' }
-	g = inkex.etree.SubElement(parent, 'g', g_attribs)
+	g = lxml.etree.SubElement(parent, 'g', g_attribs)
 
 	w = 0  #Initial spacing offset
 	spacing = 3  # spacing between letters

--- a/extensions/eggbot_spiraltext.py
+++ b/extensions/eggbot_spiraltext.py
@@ -372,28 +372,28 @@ class SpiralText( inkex.Effect ):
 
 	def __init__( self ):
 		inkex.Effect.__init__( self )
-		self.OptionParser.add_option( "--tab",	#NOTE: value is not used.
-			action="store", type="string",
+		self.arg_parser.add_argument( "--tab",	#NOTE: value is not used.
+			type=str,
 			dest="tab", default="splash",
 			help="The active tab when Apply was pressed" )
-		self.OptionParser.add_option( "--text",
-			action="store", type="string",
+		self.arg_parser.add_argument( "--text",
+			type=str,
 			dest="text", default="Hershey Text for Inkscape",
 			help="The input text to render")
-		self.OptionParser.add_option( "--fontfamily",
-			action="store", type="string",
+		self.arg_parser.add_argument( "--fontfamily",
+			type=str,
 			dest="fontfamily", default="sans",
 			help="The selected font face when Apply was pressed" )
-		self.OptionParser.add_option( "--wrap",
-			action="store", type="float",
+		self.arg_parser.add_argument( "--wrap",
+			type=float,
 			dest="wrap", default=float(10),
 			help="Number of times to wrap the text around the egg" )
-		self.OptionParser.add_option( "--flip",
-			action="store", type="inkbool",
+		self.arg_parser.add_argument( "--flip",
+			type=inkex.Boolean,
 			dest="flip", default=False,
 			help="Flip the text for plotting with the egg's bottom at the egg motor" )
-		self.OptionParser.add_option( "--stretch",
-			action="store", type="inkbool",
+		self.arg_parser.add_argument( "--stretch",
+			type=inkex.Boolean,
 			dest="stretch", default=True,
 			help="Stretch the text horizontally to account for egg distortions" )
 

--- a/extensions/eggbot_spiraltext.py
+++ b/extensions/eggbot_spiraltext.py
@@ -72,7 +72,7 @@
 import sys
 import hersheydata			#data file w/ Hershey font data
 import inkex
-import simplestyle
+
 import math
 import string
 
@@ -122,7 +122,7 @@ def draw_svg_text(char, face, offset, vertoffset, parent):
 	if i >= 0:
 		pathString = pathString[i:] #portion after first move
 		trans = 'translate(' + str(midpoint) + ',' + str(vertoffset) + ')'
-		text_attribs = {'style':simplestyle.formatStyle(style), 'd':pathString, 'transform':trans}
+		text_attribs = {'style':str(inkex.Style(style)), 'd':pathString, 'transform':trans}
 		lxml.etree.SubElement(parent, inkex.addNS('path','svg'), text_attribs)
 	return midpoint + float(splitString[1]) 	#new offset value
 

--- a/extensions/eggbot_spiraltext.py
+++ b/extensions/eggbot_spiraltext.py
@@ -69,7 +69,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-import sys
 import hersheydata			#data file w/ Hershey font data
 import inkex
 

--- a/extensions/eggbot_spiraltext.py
+++ b/extensions/eggbot_spiraltext.py
@@ -74,7 +74,6 @@ import hersheydata			#data file w/ Hershey font data
 import inkex
 
 import math
-import string
 
 import lxml.etree
 
@@ -161,7 +160,7 @@ entity_refs = { '&lt;' : '<', '&gt;' : '>', '&amp;' : '&', '&quot;' : '"', '&apo
 
 def normalize_possible_EMS_string( tag ):
 	# Normalizes tag name by removing any spaces
-	sNormalizedTag = string.replace( tag, ' ', '')
+	sNormalizedTag = tag.replace(' ', '')
 	return sNormalizedTag
 
 def is_valid_EMS_name( tag ):

--- a/extensions/eggbot_spiraltext.py
+++ b/extensions/eggbot_spiraltext.py
@@ -433,4 +433,4 @@ class SpiralText( inkex.Effect ):
 
 if __name__ == '__main__':
 	e = SpiralText()
-	e.affect()
+	e.run()

--- a/extensions/eggbot_stretch.inx
+++ b/extensions/eggbot_stretch.inx
@@ -4,7 +4,7 @@
   <id>command.eggbot.contributed.stretch</id>
   <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
   <dependency type="executable" location="extensions">eggbot_stretch.py</dependency>
-  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <dependency type="executable" location="extensions">inkex</dependency>
   <label xml:space="preserve">
 This extension will horizontally stretch your drawing.  The
 amount of stretch increases towards the poles of your egg

--- a/extensions/eggbot_stretch.inx
+++ b/extensions/eggbot_stretch.inx
@@ -1,16 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-  <_name>Stretch</_name>
+  <name>Stretch</name>
   <id>command.eggbot.contributed.stretch</id>
   <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
   <dependency type="executable" location="extensions">eggbot_stretch.py</dependency>
   <dependency type="executable" location="extensions">inkex.py</dependency>
-  <dependency type="executable" location="extensions">simpletransform.py</dependency>
-  <dependency type="executable" location="extensions">cubicsuperpath.py</dependency>
-  <dependency type="executable" location="extensions">cspsubdiv.py</dependency>
-  <dependency type="executable" location="extensions">bezmisc.py</dependency>
-
-  <_param name="Header" type="description" xml:space="preserve">
+  <label xml:space="preserve">
 This extension will horizontally stretch your drawing.  The
 amount of stretch increases towards the poles of your egg
 (i.e., increases with distance away from the equator).  The
@@ -41,20 +36,20 @@ The curve smoothing value is the same control as in the
 Eggbot Control extension.  It needs to be applied here
 before plotting as all curves will be rendered to straight
 line segments by this extension.
-  </_param>
+  </label>
 
   <param name="maxDy" type="float" min="0.0001" max="999.0"
-	 _gui-text="Vertical smoothing (lower for more)">5.0</param>
+	 gui-text="Vertical smoothing (lower for more)">5.0</param>
   <param name="smoothness" type="float" min="0.0001" max="5"
-	 _gui-text="   Curve smoothing (lower for more)">0.2</param>
+	 gui-text="   Curve smoothing (lower for more)">0.2</param>
 
   <effect needs-live-preview="false">
     <object-type>all</object-type>
     <effects-menu>
-      <submenu _name="EggBot Contributed"/>
+      <submenu name="EggBot Contributed"/>
     </effects-menu>
   </effect>
   <script>
-    <command reldir="extensions" interpreter="python">eggbot_stretch.py</command>
+    <command location="inx" interpreter="python">eggbot_stretch.py</command>
   </script>
 </inkscape-extension>

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -139,12 +139,12 @@ class Map( inkex.Effect ):
 
 		inkex.Effect.__init__( self )
 
-		self.OptionParser.add_option('--smoothness', dest='smoothness',
-			type='float', default=float( 0.2 ), action='store',
+		self.arg_parser.add_argument('--smoothness', dest='smoothness',
+			type=float, default=float( 0.2 ),
 			help='Curve smoothing (less for more)' )
 
-		self.OptionParser.add_option('--maxDy', dest='maxDy',
-			type='float', default=float( 5.0 ), action='store',
+		self.arg_parser.add_argument('--maxDy', dest='maxDy',
+			type=float, default=float( 5.0 ),
 			help='Vertical smoothing (less for more)' )
 
 		self.cx = float( N_PAGE_WIDTH ) / 2.0

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -303,7 +303,7 @@ class Map( inkex.Effect ):
 				pass
 
 			# First apply the current matrix transform to this node's transform
-			matNew = (inkex.Transform( matCurrent ) *  inkex.Transform( node.get( "transform" ) )).matrix
+			matNew = (inkex.Transform( matCurrent ) @  inkex.Transform( node.get( "transform" ) )).matrix
 
 			if node.tag == inkex.addNS( 'g', 'svg' ) or node.tag == 'g':
 
@@ -336,7 +336,7 @@ class Map( inkex.Effect ):
 					y = float( node.get( 'y', '0' ) )
 					# Note: the transform has already been applied
 					if ( x != 0 ) or (y != 0 ):
-						matNew2 = (inkex.Transform( matNew ) * inkex.Transform( 'translate(%f,%f)' % (x,y) )).matrix
+						matNew2 = (inkex.Transform( matNew ) @ inkex.Transform( 'translate(%f,%f)' % (x,y) )).matrix
 					else:
 						matNew2 = matNew
 					v = node.get( 'visibility', v )
@@ -581,7 +581,7 @@ class Map( inkex.Effect ):
 				if parent_transform is None:
 					return tr
 				else:
-					return ( inkex.Transform(parent_transform) * inkex.Transform(tr) ).matrix
+					return ( inkex.Transform(parent_transform) @ inkex.Transform(tr) ).matrix
 		else:
 			return self.docTransform
 

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -670,4 +670,4 @@ class Map( inkex.Effect ):
 if __name__ == '__main__':
 
 	e = Map()
-	e.affect()
+	e.run()

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -244,7 +244,7 @@ class Map( inkex.Effect ):
 			return None
 
 		if transform:
-			simpletransform.applyTransformToPath( transform, p )
+			inkex.Path( p ).transform( inkex.Transform(transform) ).to_arrays()
 
 		# Now traverse the cubic super path
 		subpath_list = []

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -26,6 +26,8 @@ import cubicsuperpath
 import cspsubdiv
 import bezmisc
 
+import lxml.etree
+
 N_PAGE_WIDTH = 3200
 N_PAGE_HEIGHT = 800
 
@@ -589,7 +591,7 @@ class Map( inkex.Effect ):
 					# We simply copy all of the attributes from
 					# the old element to this new element even though
 					# some of the attributes are no longer relevant
-					newNode = inkex.etree.Element( inkex.addNS( 'path', 'svg' ), node.attrib )
+					newNode = lxml.etree.Element( inkex.addNS( 'path', 'svg' ), node.attrib )
 					newNode.set( 'd', self.paths[node][1:] )
 
 					# Now replace the old element with this element

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -646,8 +646,8 @@ class Map( inkex.Effect ):
 		if self.options.ids:
 			# Traverse the selected objects
 			for id in self.options.ids:
-				transform = self.recursivelyGetEnclosingTransform( self.selected[id] )
-				self.recursivelyTraverseSvg( [self.selected[id]], transform, find_bbox=True )
+				transform = self.recursivelyGetEnclosingTransform( self.svg.selected[id] )
+				self.recursivelyTraverseSvg( [self.svg.selected[id]], transform, find_bbox=True )
 			# Use as the vertical centerline the midpoint between
 			# the bounding box's extremal X coordinates
 			self.cx = 0.5 * ( self.xmin + self.xmax )

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -241,7 +241,7 @@ class Map( inkex.Effect ):
 			return None
 
 		if transform:
-			inkex.Path( p ).transform( inkex.Transform(transform) ).to_arrays()
+			p = inkex.Path( p ).transform( inkex.Transform(transform) ).to_arrays()
 
 		# Now traverse the cubic super path
 		subpath_list = []

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -20,7 +20,7 @@
 import math
 import inkex
 import simplepath
-import simplestyle
+
 import simpletransform
 import cubicsuperpath
 import cspsubdiv

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -544,7 +544,7 @@ class Map( inkex.Effect ):
 
 				pass
 
-			elif not isinstance( node.tag, basestring ):
+			elif not isinstance( node.tag, str ):
 
 				pass
 

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -572,7 +572,7 @@ class Map( inkex.Effect ):
 
 			elif node.tag == inkex.addNS( 'path', 'svg' ):
 
-				if self.paths.has_key( node ):
+				if node in self.paths:
 					# Change the path data to be the new path
 					node.set( 'd', self.paths[node][1:] )
 					del self.paths[node]
@@ -586,7 +586,7 @@ class Map( inkex.Effect ):
 				node.tag == inkex.addNS( 'circle', 'svg' ) or node.tag == 'circle':
 				# Replace this element with a <path> element
 
-				if self.paths.has_key( node ):
+				if node in self.paths:
 					# Create a new <path> element
 					# We simply copy all of the attributes from
 					# the old element to this new element even though

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -241,7 +241,9 @@ class Map( inkex.Effect ):
 			return None
 
 		if transform:
-			p = inkex.Path( p ).transform( inkex.Transform(transform) ).to_arrays()
+			p = p.transform( inkex.Transform(transform) )
+		# Subdivide into smaller path segments with given smoothness
+		inkex.bezier.cspsubdiv(p, float( self.options.smoothness ))
 
 		# Now traverse the cubic super path
 		subpath_list = []
@@ -251,7 +253,6 @@ class Map( inkex.Effect ):
 				subpath_list.append( subpath_vertices )
 			subpath_vertices = []
 			last_csp = None
-			subdivideCubicPath( sp, float( self.options.smoothness ) )
 			for csp in sp:
 				if (last_csp is not None) and (math.fabs(csp[1][1] - last_csp[1]) > self.options.maxDy):
 					dy = ( csp[1][1] - last_csp[1] )

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -195,7 +195,7 @@ class Map( inkex.Effect ):
 
 		self.docHeight = self.getLength( 'height', N_PAGE_HEIGHT )
 		self.docWidth = self.getLength( 'width', N_PAGE_WIDTH )
-		if ( self.docHeight == None ) or ( self.docWidth == None ):
+		if (self.docHeight is None) or (self.docWidth is None):
 			return False
 		else:
 			return True
@@ -253,7 +253,7 @@ class Map( inkex.Effect ):
 			last_csp = None
 			subdivideCubicPath( sp, float( self.options.smoothness ) )
 			for csp in sp:
-				if ( last_csp != None ) and ( math.fabs( csp[1][1] - last_csp[1] ) > self.options.maxDy ):
+				if (last_csp is not None) and (math.fabs(csp[1][1] - last_csp[1]) > self.options.maxDy):
 					dy = ( csp[1][1] - last_csp[1] )
 					dx = ( csp[1][0] - last_csp[0] )
 					nsteps = math.ceil( math.fabs( dy / self.options.maxDy ) )
@@ -292,13 +292,13 @@ class Map( inkex.Effect ):
 		for subpath in self.paths[node]:
 			lastPoint = subpath[0]
 			lastPoint[0] = self.cx + ( lastPoint[0] - self.cx ) / math.cos( ( lastPoint[1] - self.cy ) * steps2rads )
-			if invTransform != None:
+			if invTransform is not None:
 				lastPoint = inkex.Transform( invTransform ).apply_to_point( lastPoint )
 			newPath += ' M %f,%f' % ( lastPoint[0], lastPoint[1] )
 			for point in subpath[1:]:
 				x = self.cx + ( point[0] - self.cx ) / math.cos( ( point[1] - self.cy ) * steps2rads )
 				pt = (x, point[1] )
-				if invTransform != None:
+				if invTransform is not None:
 					pt = inkex.Transform( invTransform ).apply_to_point( pt )
 				newPath += ' l %f,%f' % ( pt[0] - lastPoint[0], pt[1] - lastPoint[1] )
 				lastPoint = pt
@@ -403,12 +403,11 @@ class Map( inkex.Effect ):
 					pass
 				w = float( node.get( 'width', '0' ) )
 				h = float( node.get( 'height', '0' ) )
-				a = []
-				a.append( ['M', [x, y]] )
-				a.append( ['l', [w, 0]] )
-				a.append( ['l', [0, h]] )
-				a.append( ['l', [-w, 0]] )
-				a.append( ['Z', []] )
+				a = [['M', [x, y]],
+					 ['l', [w, 0]],
+					 ['l', [0, h]],
+					 ['l', [-w, 0]],
+					 ['Z', []]]
 				self.getPathVertices( str(inkex.Path( a )), node, matNew, find_bbox )
 
 			elif node.tag == inkex.addNS( 'line', 'svg' ) or node.tag == 'line':
@@ -427,9 +426,8 @@ class Map( inkex.Effect ):
 				y2 = float( node.get( 'y2' ) )
 				if ( not x1 ) or ( not y1 ) or ( not x2 ) or ( not y2 ):
 					pass
-				a = []
-				a.append( ['M', [x1, y1]] )
-				a.append( ['L', [x2, y2]] )
+				a = [['M', [x1, y1]],
+					 ['L', [x2, y2]]]
 				self.getPathVertices( str(inkex.Path( a )), node, matNew, find_bbox )
 
 			elif node.tag == inkex.addNS( 'polyline', 'svg' ) or node.tag == 'polyline':

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -312,7 +312,7 @@ class Map( inkex.Effect ):
 		self.paths[node] = newPath
 
 	def recursivelyTraverseSvg( self, aNodeList,
-		matCurrent=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+		matCurrent=((1.0, 0.0, 0.0), (0.0, 1.0, 0.0)),
 		parent_visibility='visible', find_bbox=False ):
 
 		'''
@@ -344,7 +344,7 @@ class Map( inkex.Effect ):
 				pass
 
 			# First apply the current matrix transform to this node's tranform
-			matNew = simpletransform.composeTransform( matCurrent, Transform( node.get( "transform" ) ).matrix )
+			matNew = (Transform( matCurrent ) *  Transform( node.get( "transform" ) )).matrix
 
 			if node.tag == inkex.addNS( 'g', 'svg' ) or node.tag == 'g':
 
@@ -377,9 +377,9 @@ class Map( inkex.Effect ):
 					y = float( node.get( 'y', '0' ) )
 					# Note: the transform has already been applied
 					if ( x != 0 ) or (y != 0 ):
-					       	matNew2 = composeTransform( matNew, Transform( 'translate(%f,%f)' % (x,y) ).matrix )
+						matNew2 = (Transform( matNew ) * Transform( 'translate(%f,%f)' % (x,y) )).matrix
 					else:
-					       	matNew2 = matNew
+						matNew2 = matNew
 					v = node.get( 'visibility', v )
 					self.recursivelyTraverseSvg( refnode, matNew2, v, find_bbox )
 
@@ -624,7 +624,7 @@ class Map( inkex.Effect ):
 				if parent_transform is None:
 					return tr
 				else:
-					return simpletransform.composeTransform( parent_transform, tr )
+					return ( Transform(parent_transform) * Transform(tr) ).matrix
 		else:
 			return self.docTransform
 

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -20,6 +20,7 @@
 import math
 import inkex
 import simplepath
+from inkex.paths import Path
 
 import simpletransform
 import cubicsuperpath
@@ -413,7 +414,7 @@ class Map( inkex.Effect ):
 				a.append( [' l ', [0, h]] )
 				a.append( [' l ', [-w, 0]] )
 				a.append( [' Z', []] )
-				self.getPathVertices( simplepath.formatPath( a ), node, matNew, find_bbox )
+				self.getPathVertices( str(Path( a )), node, matNew, find_bbox )
 
 			elif node.tag == inkex.addNS( 'line', 'svg' ) or node.tag == 'line':
 
@@ -434,7 +435,7 @@ class Map( inkex.Effect ):
 				a = []
 				a.append( ['M ', [x1, y1]] )
 				a.append( [' L ', [x2, y2]] )
-				self.getPathVertices( simplepath.formatPath( a ), node, matNew, find_bbox )
+				self.getPathVertices( str(Path( a )), node, matNew, find_bbox )
 
 			elif node.tag == inkex.addNS( 'polyline', 'svg' ) or node.tag == 'polyline':
 

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -19,8 +19,6 @@
 
 import math
 import inkex
-import simplepath
-from inkex.paths import Path
 
 import simpletransform
 from inkex.transforms import Transform
@@ -234,8 +232,8 @@ class Map( inkex.Effect ):
 			# Nothing to do
 			return None
 
-		# parsePath() may raise an exception.  This is okay
-		sp = simplepath.parsePath( path )
+		# Path() may raise an exception.  This is okay
+		sp = inkex.Path( path ).to_arrays()
 		if ( not sp ) or ( len( sp ) == 0 ):
 			# Path must have been devoid of any real content
 			return None
@@ -415,7 +413,7 @@ class Map( inkex.Effect ):
 				a.append( ['l', [0, h]] )
 				a.append( ['l', [-w, 0]] )
 				a.append( ['Z', []] )
-				self.getPathVertices( str(Path( a )), node, matNew, find_bbox )
+				self.getPathVertices( str(inkex.Path( a )), node, matNew, find_bbox )
 
 			elif node.tag == inkex.addNS( 'line', 'svg' ) or node.tag == 'line':
 
@@ -436,7 +434,7 @@ class Map( inkex.Effect ):
 				a = []
 				a.append( ['M', [x1, y1]] )
 				a.append( ['L', [x2, y2]] )
-				self.getPathVertices( str(Path( a )), node, matNew, find_bbox )
+				self.getPathVertices( str(inkex.Path( a )), node, matNew, find_bbox )
 
 			elif node.tag == inkex.addNS( 'polyline', 'svg' ) or node.tag == 'polyline':
 

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -409,11 +409,11 @@ class Map( inkex.Effect ):
 				w = float( node.get( 'width', '0' ) )
 				h = float( node.get( 'height', '0' ) )
 				a = []
-				a.append( ['M ', [x, y]] )
-				a.append( [' l ', [w, 0]] )
-				a.append( [' l ', [0, h]] )
-				a.append( [' l ', [-w, 0]] )
-				a.append( [' Z', []] )
+				a.append( ['M', [x, y]] )
+				a.append( ['l', [w, 0]] )
+				a.append( ['l', [0, h]] )
+				a.append( ['l', [-w, 0]] )
+				a.append( ['Z', []] )
 				self.getPathVertices( str(Path( a )), node, matNew, find_bbox )
 
 			elif node.tag == inkex.addNS( 'line', 'svg' ) or node.tag == 'line':
@@ -433,8 +433,8 @@ class Map( inkex.Effect ):
 				if ( not x1 ) or ( not y1 ) or ( not x2 ) or ( not y2 ):
 					pass
 				a = []
-				a.append( ['M ', [x1, y1]] )
-				a.append( [' L ', [x2, y2]] )
+				a.append( ['M', [x1, y1]] )
+				a.append( ['L', [x2, y2]] )
 				self.getPathVertices( str(Path( a )), node, matNew, find_bbox )
 
 			elif node.tag == inkex.addNS( 'polyline', 'svg' ) or node.tag == 'polyline':
@@ -454,7 +454,7 @@ class Map( inkex.Effect ):
 					pass
 
 				pa = pl.split()
-				d = "".join( ["M " + pa[i] if i == 0 else " L " + pa[i] for i in range( 0, len( pa ) )] )
+				d = " ".join( ["M" + pa[i] if i == 0 else "L" + pa[i] for i in range( 0, len( pa ) )] )
 				self.getPathVertices( d, node, matNew, find_bbox )
 
 			elif node.tag == inkex.addNS( 'polygon', 'svg' ) or node.tag == 'polygon':
@@ -474,8 +474,8 @@ class Map( inkex.Effect ):
 					pass
 
 				pa = pl.split()
-				d = "".join( ["M " + pa[i] if i == 0 else " L " + pa[i] for i in range( 0, len( pa ) )] )
-				d += " Z"
+				d = " ".join( ["M" + pa[i] if i == 0 else "L" + pa[i] for i in range( 0, len( pa ) )] )
+				d += "Z"
 				self.getPathVertices( d, node, matNew, find_bbox )
 
 			elif node.tag == inkex.addNS( 'ellipse', 'svg' ) or \

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -20,8 +20,6 @@
 import math
 import inkex
 
-import simpletransform
-from inkex.transforms import Transform
 import inkex.bezier
 import bezmisc
 
@@ -216,7 +214,7 @@ class Map( inkex.Effect ):
 				if ( vinfo[2] != 0 ) and ( vinfo[3] != 0 ):
 					sx = self.docWidth / float( vinfo[2] )
 					sy = self.docHeight / float( vinfo[3] )
-					self.docTransform = Transform( 'scale(%f,%f)' % (sx, sy) ).matrix
+					self.docTransform = inkex.Transform( 'scale(%f,%f)' % (sx, sy) ).matrix
 
 	def getPathVertices( self, path, node=None, transform=None, find_bbox=False ):
 
@@ -296,13 +294,13 @@ class Map( inkex.Effect ):
 			lastPoint = subpath[0]
 			lastPoint[0] = self.cx + ( lastPoint[0] - self.cx ) / math.cos( ( lastPoint[1] - self.cy ) * steps2rads )
 			if invTransform != None:
-				simpletransform.applyTransformToPoint( invTransform, lastPoint )
+				lastPoint = inkex.Transform( invTransform ).apply_to_point( lastPoint )
 			newPath += ' M %f,%f' % ( lastPoint[0], lastPoint[1] )
 			for point in subpath[1:]:
 				x = self.cx + ( point[0] - self.cx ) / math.cos( ( point[1] - self.cy ) * steps2rads )
 				pt = [x, point[1] ]
 				if invTransform != None:
-					simpletransform.applyTransformToPoint( invTransform, pt )
+					pt = inkex.Transform( invTransform ).apply_to_point( pt )
 				newPath += ' l %f,%f' % ( pt[0] - lastPoint[0], pt[1] - lastPoint[1] )
 				lastPoint = pt
 
@@ -341,7 +339,7 @@ class Map( inkex.Effect ):
 				pass
 
 			# First apply the current matrix transform to this node's tranform
-			matNew = (Transform( matCurrent ) *  Transform( node.get( "transform" ) )).matrix
+			matNew = (inkex.Transform( matCurrent ) *  inkex.Transform( node.get( "transform" ) )).matrix
 
 			if node.tag == inkex.addNS( 'g', 'svg' ) or node.tag == 'g':
 
@@ -374,7 +372,7 @@ class Map( inkex.Effect ):
 					y = float( node.get( 'y', '0' ) )
 					# Note: the transform has already been applied
 					if ( x != 0 ) or (y != 0 ):
-						matNew2 = (Transform( matNew ) * Transform( 'translate(%f,%f)' % (x,y) )).matrix
+						matNew2 = (inkex.Transform( matNew ) * inkex.Transform( 'translate(%f,%f)' % (x,y) )).matrix
 					else:
 						matNew2 = matNew
 					v = node.get( 'visibility', v )
@@ -617,11 +615,11 @@ class Map( inkex.Effect ):
 			if node_transform is None:
 				return parent_transform
 			else:
-				tr = Transform( node_transform ).matrix
+				tr = inkex.Transform( node_transform ).matrix
 				if parent_transform is None:
 					return tr
 				else:
-					return ( Transform(parent_transform) * Transform(tr) ).matrix
+					return ( inkex.Transform(parent_transform) * inkex.Transform(tr) ).matrix
 		else:
 			return self.docTransform
 

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -297,7 +297,7 @@ class Map( inkex.Effect ):
 			newPath += ' M %f,%f' % ( lastPoint[0], lastPoint[1] )
 			for point in subpath[1:]:
 				x = self.cx + ( point[0] - self.cx ) / math.cos( ( point[1] - self.cy ) * steps2rads )
-				pt = [x, point[1] ]
+				pt = (x, point[1] )
 				if invTransform != None:
 					pt = inkex.Transform( invTransform ).apply_to_point( pt )
 				newPath += ' l %f,%f' % ( pt[0] - lastPoint[0], pt[1] - lastPoint[1] )
@@ -337,7 +337,7 @@ class Map( inkex.Effect ):
 			if v == 'hidden' or v == 'collapse':
 				pass
 
-			# First apply the current matrix transform to this node's tranform
+			# First apply the current matrix transform to this node's transform
 			matNew = (inkex.Transform( matCurrent ) *  inkex.Transform( node.get( "transform" ) )).matrix
 
 			if node.tag == inkex.addNS( 'g', 'svg' ) or node.tag == 'g':
@@ -512,7 +512,7 @@ class Map( inkex.Effect ):
 						'0 1 0 %f,%f ' % ( x2, cy ) + \
 						'A %f,%f ' % ( rx, ry ) + \
 						'0 1 0 %f,%f' % ( x1, cy )
-					self.mapPathVertices( d, node, matNew, find_bbox )
+					self.getPathVertices( d, node, matNew, find_bbox )
 
 			elif node.tag == inkex.addNS( 'pattern', 'svg' ) or node.tag == 'pattern':
 
@@ -663,7 +663,7 @@ class Map( inkex.Effect ):
 		# WE DO NOT compute and replace the paths in the same pass!
 		# So doing can cause multiple transformations of cloned paths
 
-		self.recursivelyReplaceSvg( self.document.getroot(), self.docTransform )
+		self.recursivelyReplaceSvg( self.document.getroot() )
 
 if __name__ == '__main__':
 

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -94,42 +94,6 @@ def parseLengthWithUnits( str ):
 
 	return v, u
 
-def subdivideCubicPath( sp, flat, i=1 ):
-
-	'''
-	[ Lifted from eggbot.py with impunity ]
-
-	Break up a bezier curve into smaller curves, each of which
-	is approximately a straight line within a given tolerance
-	(the "smoothness" defined by [flat]).
-
-	This is a modified version of inkex.bezier.cspsubdiv(): rewritten
-	because recursion-depth errors on complicated line segments
-	could occur with inkex.bezier.cspsubdiv().
-	'''
-
-	while True:
-		while True:
-			if i >= len( sp ):
-				return
-
-			p0 = sp[i - 1][1]
-			p1 = sp[i - 1][2]
-			p2 = sp[i][0]
-			p3 = sp[i][1]
-
-			b = ( p0, p1, p2, p3 )
-
-			if inkex.bezier.maxdist( b ) > flat:
-				break
-
-			i += 1
-
-		one, two = inkex.bezier.beziersplitatt( b, 0.5 )
-		sp[i - 1][2] = one[1]
-		sp[i][0] = two[2]
-		p = [one[2], one[3], two[1]]
-		sp[i:1] = [p]
 
 class Map( inkex.Effect ):
 

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -21,7 +21,6 @@ import math
 import inkex
 
 import inkex.bezier
-import bezmisc
 
 import lxml.etree
 
@@ -126,7 +125,7 @@ def subdivideCubicPath( sp, flat, i=1 ):
 
 			i += 1
 
-		one, two = bezmisc.beziersplitatt( b, 0.5 )
+		one, two = inkex.bezier.beziersplitatt( b, 0.5 )
 		sp[i - 1][2] = one[1]
 		sp[i][0] = two[2]
 		p = [one[2], one[3], two[1]]

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -23,6 +23,7 @@ import simplepath
 from inkex.paths import Path
 
 import simpletransform
+from inkex.transforms import Transform
 import cubicsuperpath
 import cspsubdiv
 import bezmisc
@@ -218,7 +219,7 @@ class Map( inkex.Effect ):
 				if ( vinfo[2] != 0 ) and ( vinfo[3] != 0 ):
 					sx = self.docWidth / float( vinfo[2] )
 					sy = self.docHeight / float( vinfo[3] )
-					self.docTransform = simpletransform.parseTransform( 'scale(%f,%f)' % (sx, sy) )
+					self.docTransform = Transform( 'scale(%f,%f)' % (sx, sy) ).matrix
 
 	def getPathVertices( self, path, node=None, transform=None, find_bbox=False ):
 
@@ -343,7 +344,7 @@ class Map( inkex.Effect ):
 				pass
 
 			# First apply the current matrix transform to this node's tranform
-			matNew = simpletransform.composeTransform( matCurrent, simpletransform.parseTransform( node.get( "transform" ) ) )
+			matNew = simpletransform.composeTransform( matCurrent, Transform( node.get( "transform" ) ).matrix )
 
 			if node.tag == inkex.addNS( 'g', 'svg' ) or node.tag == 'g':
 
@@ -376,7 +377,7 @@ class Map( inkex.Effect ):
 					y = float( node.get( 'y', '0' ) )
 					# Note: the transform has already been applied
 					if ( x != 0 ) or (y != 0 ):
-					       	matNew2 = composeTransform( matNew, parseTransform( 'translate(%f,%f)' % (x,y) ) )
+					       	matNew2 = composeTransform( matNew, Transform( 'translate(%f,%f)' % (x,y) ).matrix )
 					else:
 					       	matNew2 = matNew
 					v = node.get( 'visibility', v )
@@ -619,7 +620,7 @@ class Map( inkex.Effect ):
 			if node_transform is None:
 				return parent_transform
 			else:
-				tr = simpletransform.parseTransform( node_transform )
+				tr = Transform( node_transform ).matrix
 				if parent_transform is None:
 					return tr
 				else:

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -22,7 +22,7 @@ import inkex
 
 import simpletransform
 from inkex.transforms import Transform
-import cspsubdiv
+import inkex.bezier
 import bezmisc
 
 import lxml.etree
@@ -106,9 +106,9 @@ def subdivideCubicPath( sp, flat, i=1 ):
 	is approximately a straight line within a given tolerance
 	(the "smoothness" defined by [flat]).
 
-	This is a modified version of cspsubdiv.cspsubdiv(): rewritten
+	This is a modified version of inkex.bezier.cspsubdiv(): rewritten
 	because recursion-depth errors on complicated line segments
-	could occur with cspsubdiv.cspsubdiv().
+	could occur with inkex.bezier.cspsubdiv().
 	'''
 
 	while True:
@@ -123,7 +123,7 @@ def subdivideCubicPath( sp, flat, i=1 ):
 
 			b = ( p0, p1, p2, p3 )
 
-			if cspsubdiv.maxdist( b ) > flat:
+			if inkex.bezier.maxdist( b ) > flat:
 				break
 
 			i += 1

--- a/extensions/eggbot_stretch.py
+++ b/extensions/eggbot_stretch.py
@@ -22,7 +22,6 @@ import inkex
 
 import simpletransform
 from inkex.transforms import Transform
-import cubicsuperpath
 import cspsubdiv
 import bezmisc
 
@@ -239,7 +238,7 @@ class Map( inkex.Effect ):
 			return None
 
 		# Get a cubic super path
-		p = cubicsuperpath.CubicSuperPath( sp )
+		p = inkex.Path( sp ).to_superpath()
 		if ( not p ) or ( len( p ) == 0 ):
 			# Probably never happens, but...
 			return None

--- a/extensions/eggbot_stripdata.inx
+++ b/extensions/eggbot_stripdata.inx
@@ -4,7 +4,7 @@
   <id>command.evilmadscience.eggbot_stripdata1.eggbot</id>
   <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
   <dependency type="executable" location="extensions">eggbot_stripdata.py</dependency>
-  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <dependency type="executable" location="extensions">inkex</dependency>
   <effect needs-live-preview="false" needs-document="false">
 		<object-type>all</object-type>
 	<effects-menu>

--- a/extensions/eggbot_stripdata.inx
+++ b/extensions/eggbot_stripdata.inx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-  <_name>Strip Eggbot Data</_name>
+  <name>Strip Eggbot Data</name>
   <id>command.evilmadscience.eggbot_stripdata1.eggbot</id>
   <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
   <dependency type="executable" location="extensions">eggbot_stripdata.py</dependency>
   <dependency type="executable" location="extensions">inkex.py</dependency>
-  <effect needs-live-preview="false" needs-document="no">
+  <effect needs-live-preview="false" needs-document="false">
 		<object-type>all</object-type>
 	<effects-menu>
-		<submenu _name="EggBot"/>
+		<submenu name="EggBot"/>
 	</effects-menu>
   </effect>
   <script>
-    <command reldir="extensions" interpreter="python">eggbot_stripdata.py</command>
+    <command location="inx" interpreter="python">eggbot_stripdata.py</command>
   </script>
 </inkscape-extension>

--- a/extensions/eggbot_stripdata.py
+++ b/extensions/eggbot_stripdata.py
@@ -27,4 +27,4 @@ class EggBotStripData( inkex.Effect ):
 		inkex.errormsg( gettext.gettext( "Okay, I've removed all Eggbot data from this Inkscape file.  Have a nice day!" ) )
 
 e = EggBotStripData()
-e.affect()
+e.run()

--- a/extensions/eggbot_twist.inx
+++ b/extensions/eggbot_twist.inx
@@ -1,18 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-  <_name>Twist</_name>
+  <name>Twist</name>
   <id>command.eggbot.contributed.twist</id>
   <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
   <dependency type="executable" location="extensions">eggbot_twist.py</dependency>
   <dependency type="executable" location="extensions">inkex.py</dependency>
-  <dependency type="executable" location="extensions">simplepath.py</dependency>
-  <dependency type="executable" location="extensions">simpletransform.py</dependency>
-  <dependency type="executable" location="extensions">simplestyle.py</dependency>
-  <dependency type="executable" location="extensions">cubicsuperpath.py</dependency>
-  <dependency type="executable" location="extensions">cspsubdiv.py</dependency>
-  <dependency type="executable" location="extensions">bezmisc.py</dependency>
 
-  <_param name="Header" type="description" xml:space="preserve">
+  <label xml:space="preserve">
 Iteratively twist and self-inscribe
 a polygon within itself.
 
@@ -31,20 +25,20 @@ See the eggbot_twist.py file in the
 Inkscape extensions directory for
 this extensions' Python code.
 ***
-  </_param>
+  </label>
 
   <param name="nSteps" type="int" min="1" max="100"
-	 _gui-text="   Number of twists">8</param>
+	 gui-text="   Number of twists">8</param>
   <param name="fRatio" type="float" min="-10" max="10" precision="5"
-	 _gui-text="   Step ratio">0.15</param>
+	 gui-text="   Step ratio">0.15</param>
 
   <effect needs-live-preview="false">
     <object-type>all</object-type>
     <effects-menu>
-      <submenu _name="EggBot Contributed"/>
+      <submenu name="EggBot Contributed"/>
     </effects-menu>
   </effect>
   <script>
-    <command reldir="extensions" interpreter="python">eggbot_twist.py</command>
+    <command location="inx" interpreter="python">eggbot_twist.py</command>
   </script>
 </inkscape-extension>

--- a/extensions/eggbot_twist.inx
+++ b/extensions/eggbot_twist.inx
@@ -4,7 +4,7 @@
   <id>command.eggbot.contributed.twist</id>
   <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
   <dependency type="executable" location="extensions">eggbot_twist.py</dependency>
-  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <dependency type="executable" location="extensions">inkex</dependency>
 
   <label xml:space="preserve">
 Iteratively twist and self-inscribe

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -39,6 +39,8 @@ import cubicsuperpath
 import cspsubdiv
 import bezmisc
 
+import lxml.etree
+
 def subdivideCubicPath( sp, flat, i=1 ):
 
 	'''
@@ -461,7 +463,7 @@ class Twist( inkex.Effect ):
 			#was: if not parent:
 			if parent is None:
 				parent = self.document.getroot()
-			g = inkex.etree.SubElement( parent, inkex.addNS( 'g', 'svg' ) )
+			g = lxml.etree.SubElement( parent, inkex.addNS( 'g', 'svg' ) )
 
 			# Move node to be a child of this new <g> element
 			g.append( node )
@@ -482,7 +484,7 @@ class Twist( inkex.Effect ):
 		line_attribs = { 'style':simplestyle.formatStyle( style ), 'd': path }
 		if ( cloneTransform != None ) and ( cloneTransform != '' ):
 			line_attribs['transform'] = cloneTransform
-		inkex.etree.SubElement( g, inkex.addNS( 'path', 'svg' ), line_attribs )
+		lxml.etree.SubElement( g, inkex.addNS( 'path', 'svg' ), line_attribs )
 
 	def twist( self, ratio ):
 

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -95,12 +95,12 @@ class Twist( inkex.Effect ):
 	def __init__( self ):
 
 		inkex.Effect.__init__( self )
-		self.OptionParser.add_option(
-			"--nSteps", action="store", type="int",
+		self.arg_parser.add_argument(
+			"--nSteps", type=int,
 			dest="nSteps", default=8,
 			help="Number of iterations to take" )
-		self.OptionParser.add_option(
-			"--fRatio", action="store", type="float",
+		self.arg_parser.add_argument(
+			"--fRatio", type=float,
 			dest="fRatio", default=float( 0.2 ),
 			help="Some ratio" )
 

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -526,7 +526,7 @@ class Twist( inkex.Effect ):
 		if self.options.ids:
 			# Traverse the selected objects
 			for id in self.options.ids:
-				self.recursivelyTraverseSvg( [self.selected[id]] )
+				self.recursivelyTraverseSvg( [self.svg.selected[id]] )
 		else:
 			# Traverse the entire document
 			self.recursivelyTraverseSvg( self.document.getroot() )

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -38,42 +38,6 @@ import inkex.bezier
 
 import lxml.etree
 
-def subdivideCubicPath( sp, flat, i=1 ):
-
-	'''
-	[ Lifted from eggbot.py with impunity ]
-
-	Break up a bezier curve into smaller curves, each of which
-	is approximately a straight line within a given tolerance
-	(the "smoothness" defined by [flat]).
-
-	This is a modified version of inkex.bezier.cspsubdiv(): rewritten
-	because recursion-depth errors on complicated line segments
-	could occur with inkex.bezier.cspsubdiv().
-	'''
-
-	while True:
-		while True:
-			if i >= len( sp ):
-				return
-
-			p0 = sp[i - 1][1]
-			p1 = sp[i - 1][2]
-			p2 = sp[i][0]
-			p3 = sp[i][1]
-
-			b = ( p0, p1, p2, p3 )
-
-			if inkex.bezier.maxdist( b ) > flat:
-				break
-
-			i += 1
-
-		one, two = inkex.bezier.beziersplitatt( b, 0.5 )
-		sp[i - 1][2] = one[1]
-		sp[i][0] = two[2]
-		p = [one[2], one[3], two[1]]
-		sp[i:1] = [p]
 
 def distanceSquared( P1, P2 ):
 

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -33,7 +33,7 @@
 
 import inkex
 import simplepath
-import simplestyle
+
 import simpletransform
 import cubicsuperpath
 import cspsubdiv
@@ -481,7 +481,7 @@ class Twist( inkex.Effect ):
 		# Now make a <path> element which contains the twist & is a child
 		# of the new <g> element
 		style = { 'stroke': '#000000', 'fill': 'none', 'stroke-width': '1' }
-		line_attribs = { 'style':simplestyle.formatStyle( style ), 'd': path }
+		line_attribs = { 'style':str(inkex.Style( style )), 'd': path }
 		if ( cloneTransform != None ) and ( cloneTransform != '' ):
 			line_attribs['transform'] = cloneTransform
 		lxml.etree.SubElement( g, inkex.addNS( 'path', 'svg' ), line_attribs )

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -36,6 +36,7 @@ import simplepath
 from inkex.paths import Path
 
 import simpletransform
+from inkex.transforms import Transform
 import cubicsuperpath
 import cspsubdiv
 import bezmisc
@@ -234,7 +235,7 @@ class Twist( inkex.Effect ):
 
 			# First apply the current matrix transform to this node's tranform
 			matNew = simpletransform.composeTransform( matCurrent,
-				simpletransform.parseTransform( node.get( "transform" ) ) )
+				Transform( node.get( "transform" ) ).matrix )
 
 			if node.tag == inkex.addNS( 'g', 'svg' ) or node.tag == 'g':
 
@@ -267,7 +268,7 @@ class Twist( inkex.Effect ):
 					y = float( node.get( 'y', '0' ) )
 					# Note: the transform has already been applied
 					if ( x != 0 ) or (y != 0 ):
-						matNew2 = composeTransform( matNew, parseTransform( 'translate(%f,%f)' % (x,y) ) )
+						matNew2 = composeTransform( matNew, Transform( 'translate(%f,%f)' % (x,y) ).matrix )
 					else:
 						matNew2 = matNew
 					v = node.get( 'visibility', v )

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -166,7 +166,7 @@ class Twist( inkex.Effect ):
 			return
 
 		#if transform:
-		#	simpletransform.applyTransformToPath( transform, p )
+		#	inkex.Path(p).transform(inkex.Transform(transform)).to_arrays()
 
 		# Now traverse the cubic super path
 		subpath_list = []

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -194,7 +194,7 @@ class Twist( inkex.Effect ):
 				pass
 
 			# First apply the current matrix transform to this node's tranform
-			matNew = ( Transform(matCurrent) * Transform( node.get( "transform" ) ) ).matrix
+			matNew = ( Transform(matCurrent) @ Transform( node.get( "transform" ) ) ).matrix
 
 			if node.tag == inkex.addNS( 'g', 'svg' ) or node.tag == 'g':
 
@@ -227,7 +227,7 @@ class Twist( inkex.Effect ):
 					y = float( node.get( 'y', '0' ) )
 					# Note: the transform has already been applied
 					if ( x != 0 ) or (y != 0 ):
-						matNew2 = ( Transform(matNew) * Transform( 'translate(%f,%f)' % (x,y) ) ).matrix
+						matNew2 = ( Transform(matNew) @ Transform( 'translate(%f,%f)' % (x,y) ) ).matrix
 					else:
 						matNew2 = matNew
 					v = node.get( 'visibility', v )

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -34,7 +34,7 @@
 import inkex
 
 from inkex.transforms import Transform
-import cspsubdiv
+import inkex.bezier
 import bezmisc
 
 import lxml.etree
@@ -48,9 +48,9 @@ def subdivideCubicPath( sp, flat, i=1 ):
 	is approximately a straight line within a given tolerance
 	(the "smoothness" defined by [flat]).
 
-	This is a modified version of cspsubdiv.cspsubdiv(): rewritten
+	This is a modified version of inkex.bezier.cspsubdiv(): rewritten
 	because recursion-depth errors on complicated line segments
-	could occur with cspsubdiv.cspsubdiv().
+	could occur with inkex.bezier.cspsubdiv().
 	'''
 
 	while True:
@@ -65,7 +65,7 @@ def subdivideCubicPath( sp, flat, i=1 ):
 
 			b = ( p0, p1, p2, p3 )
 
-			if cspsubdiv.maxdist( b ) > flat:
+			if inkex.bezier.maxdist( b ) > flat:
 				break
 
 			i += 1

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -295,12 +295,11 @@ class Twist( inkex.Effect ):
 					pass
 				w = float( node.get( 'width', '0' ) )
 				h = float( node.get( 'height', '0' ) )
-				a = []
-				a.append( ['M', [x, y]] )
-				a.append( ['l', [w, 0]] )
-				a.append( ['l', [0, h]] )
-				a.append( ['l', [-w, 0]] )
-				a.append( ['Z', []] )
+				a = [['M', [x, y]],
+					 ['l', [w, 0]],
+					 ['l', [0, h]],
+					 ['l', [-w, 0]],
+					 ['Z', []]]
 				self.addPathVertices( str(inkex.Path( a )), node, matNew, cloneTransform )
 
 			elif node.tag == inkex.addNS( 'line', 'svg' ) or node.tag == 'line':
@@ -319,9 +318,8 @@ class Twist( inkex.Effect ):
 				y2 = float( node.get( 'y2' ) )
 				if ( not x1 ) or ( not y1 ) or ( not x2 ) or ( not y2 ):
 					pass
-				a = []
-				a.append( ['M', [x1, y1]] )
-				a.append( ['L', [x2, y2]] )
+				a = [['M', [x1, y1]],
+					 ['L', [x2, y2]]]
 				self.addPathVertices( str(inkex.Path( a )), node, matNew, cloneTransform )
 
 			elif node.tag == inkex.addNS( 'polyline', 'svg' ) or node.tag == 'polyline':
@@ -478,7 +476,7 @@ class Twist( inkex.Effect ):
 		# of the new <g> element
 		style = { 'stroke': '#000000', 'fill': 'none', 'stroke-width': '1' }
 		line_attribs = { 'style':str(inkex.Style( style )), 'd': path }
-		if ( cloneTransform != None ) and ( cloneTransform != '' ):
+		if (cloneTransform is not None) and (cloneTransform != ''):
 			line_attribs['transform'] = cloneTransform
 		lxml.etree.SubElement( g, inkex.addNS( 'path', 'svg' ), line_attribs )
 

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -33,6 +33,7 @@
 
 import inkex
 import simplepath
+from inkex.paths import Path
 
 import simpletransform
 import cubicsuperpath
@@ -305,7 +306,7 @@ class Twist( inkex.Effect ):
 				a.append( [' l ', [0, h]] )
 				a.append( [' l ', [-w, 0]] )
 				a.append( [' Z', []] )
-				self.addPathVertices( simplepath.formatPath( a ), node, matNew, cloneTransform )
+				self.addPathVertices( str(Path( a )), node, matNew, cloneTransform )
 
 			elif node.tag == inkex.addNS( 'line', 'svg' ) or node.tag == 'line':
 
@@ -326,7 +327,7 @@ class Twist( inkex.Effect ):
 				a = []
 				a.append( ['M ', [x1, y1]] )
 				a.append( [' L ', [x2, y2]] )
-				self.addPathVertices( simplepath.formatPath( a ), node, matNew, cloneTransform )
+				self.addPathVertices( str(Path( a )), node, matNew, cloneTransform )
 
 			elif node.tag == inkex.addNS( 'polyline', 'svg' ) or node.tag == 'polyline':
 

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -202,7 +202,7 @@ class Twist( inkex.Effect ):
 		self.paths_clone_transform[node] = cloneTransform
 
 	def recursivelyTraverseSvg( self, aNodeList,
-		matCurrent=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+		matCurrent=((1.0, 0.0, 0.0), (0.0, 1.0, 0.0)),
 		parent_visibility='visible', cloneTransform=None ):
 
 		'''
@@ -234,8 +234,7 @@ class Twist( inkex.Effect ):
 				pass
 
 			# First apply the current matrix transform to this node's tranform
-			matNew = simpletransform.composeTransform( matCurrent,
-				Transform( node.get( "transform" ) ).matrix )
+			matNew = ( Transform(matCurrent) * Transform( node.get( "transform" ) ) ).matrix
 
 			if node.tag == inkex.addNS( 'g', 'svg' ) or node.tag == 'g':
 
@@ -268,7 +267,7 @@ class Twist( inkex.Effect ):
 					y = float( node.get( 'y', '0' ) )
 					# Note: the transform has already been applied
 					if ( x != 0 ) or (y != 0 ):
-						matNew2 = composeTransform( matNew, Transform( 'translate(%f,%f)' % (x,y) ).matrix )
+						matNew2 = ( Transform(matNew) * Transform( 'translate(%f,%f)' % (x,y) ) ).matrix
 					else:
 						matNew2 = matNew
 					v = node.get( 'visibility', v )

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -165,7 +165,7 @@ class Twist( inkex.Effect ):
 			return
 
 		#if transform:
-		#	inkex.Path(p).transform(inkex.Transform(transform)).to_arrays()
+		#	p = inkex.Path(p).transform(inkex.Transform(transform)).to_arrays()
 
 		# Now traverse the cubic super path
 		subpath_list = []

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -537,4 +537,4 @@ class Twist( inkex.Effect ):
 if __name__ == '__main__':
 
 	e = Twist()
-	e.affect()
+	e.run()

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -436,7 +436,7 @@ class Twist( inkex.Effect ):
 
 				pass
 
-			elif not isinstance( node.tag, basestring ):
+			elif not isinstance( node.tag, str ):
 
 				pass
 

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -34,7 +34,6 @@
 import inkex
 
 from inkex.transforms import Transform
-import cubicsuperpath
 import cspsubdiv
 import bezmisc
 
@@ -161,7 +160,7 @@ class Twist( inkex.Effect ):
 			return
 
 		# Get a cubic super path
-		p = cubicsuperpath.CubicSuperPath( sp )
+		p = inkex.Path( sp ).to_superpath()
 		if ( not p ) or ( len( p ) == 0 ):
 			# Probably never happens, but...
 			return

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -35,7 +35,6 @@ import inkex
 
 from inkex.transforms import Transform
 import inkex.bezier
-import bezmisc
 
 import lxml.etree
 
@@ -70,7 +69,7 @@ def subdivideCubicPath( sp, flat, i=1 ):
 
 			i += 1
 
-		one, two = bezmisc.beziersplitatt( b, 0.5 )
+		one, two = inkex.bezier.beziersplitatt( b, 0.5 )
 		sp[i - 1][2] = one[1]
 		sp[i][0] = two[2]
 		p = [one[2], one[3], two[1]]

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -301,11 +301,11 @@ class Twist( inkex.Effect ):
 				w = float( node.get( 'width', '0' ) )
 				h = float( node.get( 'height', '0' ) )
 				a = []
-				a.append( ['M ', [x, y]] )
-				a.append( [' l ', [w, 0]] )
-				a.append( [' l ', [0, h]] )
-				a.append( [' l ', [-w, 0]] )
-				a.append( [' Z', []] )
+				a.append( ['M', [x, y]] )
+				a.append( ['l', [w, 0]] )
+				a.append( ['l', [0, h]] )
+				a.append( ['l', [-w, 0]] )
+				a.append( ['Z', []] )
 				self.addPathVertices( str(Path( a )), node, matNew, cloneTransform )
 
 			elif node.tag == inkex.addNS( 'line', 'svg' ) or node.tag == 'line':
@@ -325,8 +325,8 @@ class Twist( inkex.Effect ):
 				if ( not x1 ) or ( not y1 ) or ( not x2 ) or ( not y2 ):
 					pass
 				a = []
-				a.append( ['M ', [x1, y1]] )
-				a.append( [' L ', [x2, y2]] )
+				a.append( ['M', [x1, y1]] )
+				a.append( ['L', [x2, y2]] )
 				self.addPathVertices( str(Path( a )), node, matNew, cloneTransform )
 
 			elif node.tag == inkex.addNS( 'polyline', 'svg' ) or node.tag == 'polyline':
@@ -346,7 +346,7 @@ class Twist( inkex.Effect ):
 					pass
 
 				pa = pl.split()
-				d = "".join( ["M " + pa[i] if i == 0 else " L " + pa[i] for i in range( 0, len( pa ) )] )
+				d = " ".join( ["M" + pa[i] if i == 0 else "L" + pa[i] for i in range( 0, len( pa ) )] )
 				self.addPathVertices( d, node, matNew, cloneTransform )
 
 			elif node.tag == inkex.addNS( 'polygon', 'svg' ) or node.tag == 'polygon':
@@ -366,8 +366,8 @@ class Twist( inkex.Effect ):
 					pass
 
 				pa = pl.split()
-				d = "".join( ["M " + pa[i] if i == 0 else " L " + pa[i] for i in range( 0, len( pa ) )] )
-				d += " Z"
+				d = " ".join( ["M" + pa[i] if i == 0 else "L" + pa[i] for i in range( 0, len( pa ) )] )
+				d += "Z"
 				self.addPathVertices( d, node, matNew, cloneTransform )
 
 			elif node.tag == inkex.addNS( 'ellipse', 'svg' ) or \

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -32,10 +32,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 import inkex
-import simplepath
-from inkex.paths import Path
 
-import simpletransform
 from inkex.transforms import Transform
 import cubicsuperpath
 import cspsubdiv
@@ -157,8 +154,8 @@ class Twist( inkex.Effect ):
 			# Nothing to do
 			return
 
-		# parsePath() may raise an exception.  This is okay
-		sp = simplepath.parsePath( path )
+		# Path() may raise an exception.  This is okay
+		sp = inkex.Path( path ).to_arrays()
 		if ( not sp ) or ( len( sp ) == 0 ):
 			# Path must have been devoid of any real content
 			return
@@ -306,7 +303,7 @@ class Twist( inkex.Effect ):
 				a.append( ['l', [0, h]] )
 				a.append( ['l', [-w, 0]] )
 				a.append( ['Z', []] )
-				self.addPathVertices( str(Path( a )), node, matNew, cloneTransform )
+				self.addPathVertices( str(inkex.Path( a )), node, matNew, cloneTransform )
 
 			elif node.tag == inkex.addNS( 'line', 'svg' ) or node.tag == 'line':
 
@@ -327,7 +324,7 @@ class Twist( inkex.Effect ):
 				a = []
 				a.append( ['M', [x1, y1]] )
 				a.append( ['L', [x2, y2]] )
-				self.addPathVertices( str(Path( a )), node, matNew, cloneTransform )
+				self.addPathVertices( str(inkex.Path( a )), node, matNew, cloneTransform )
 
 			elif node.tag == inkex.addNS( 'polyline', 'svg' ) or node.tag == 'polyline':
 

--- a/extensions/eggbot_twist.py
+++ b/extensions/eggbot_twist.py
@@ -165,7 +165,9 @@ class Twist( inkex.Effect ):
 			return
 
 		#if transform:
-		#	p = inkex.Path(p).transform(inkex.Transform(transform)).to_arrays()
+		#	p = p.transform(inkex.Transform(transform))
+		# Subdivide into smaller path segments with given smoothness
+		inkex.bezier.cspsubdiv(p, float( 0.2 ))
 
 		# Now traverse the cubic super path
 		subpath_list = []
@@ -177,7 +179,6 @@ class Twist( inkex.Effect ):
 					# Keep the prior subpath: it appears to be a closed path
 					subpath_list.append( subpath_vertices )
 			subpath_vertices = []
-			subdivideCubicPath( sp, float( 0.2 ) )
 			for csp in sp:
 				# Add this vertex to the list of vetices
 				subpath_vertices.append( csp[1] )

--- a/extensions/hershey.inx
+++ b/extensions/hershey.inx
@@ -5,7 +5,7 @@
   <!-- Version 2.2 November 28, 2017 -->
   <dependency type="executable" location="extensions">hershey.py</dependency>
   <dependency type="executable" location="extensions">hersheydata.py</dependency>
-  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <dependency type="executable" location="extensions">inkex</dependency>
 
   <param name="tab" type="notebook">
     <page name="splash" gui-text="Render Text">

--- a/extensions/hershey.inx
+++ b/extensions/hershey.inx
@@ -107,7 +107,7 @@ For a full introduction, please visit:
   www.evilmadscientist.com/go/hershey</label>
 </page>
 
-<page name="info" gui-text="Credits">
+<page name="credits" gui-text="Credits">
 <label xml:space="preserve">
 The classic fonts included -- those without the "EMS"
 prefix -- are derived from work by Dr. A. V. Hershey,

--- a/extensions/hershey.inx
+++ b/extensions/hershey.inx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-  <_name>Hershey Text</_name>
+  <name>Hershey Text</name>
   <id>org.evilmad.render.hershe</id>
   <!-- Version 2.2 November 28, 2017 -->
   <dependency type="executable" location="extensions">hershey.py</dependency>
@@ -8,90 +8,90 @@
   <dependency type="executable" location="extensions">inkex.py</dependency>
 
   <param name="tab" type="notebook">
-    <page name="splash" _gui-text="Render Text">
+    <page name="splash" gui-text="Render Text">
 
-<_param indent="1" name="splashpage" type="description" appearance="header">
+<label indent="1" name="splashpage" appearance="header">
 Hershey Text: Engraving Fonts for Inkscape
 
-</_param>
-      <param indent="2" name="text" type="string" _gui-text="Text:">The Quick Brown Fox Jumps Over a Lazy Dog</param>
+</label>
+      <param indent="2" name="text" type="string" gui-text="Text:">The Quick Brown Fox Jumps Over a Lazy Dog</param>
 
-      <param indent="2" name="action" type="enum" _gui-text="Action: ">
-        <_item value="render"   >Typeset that text</_item>
-        <_item value="sample"   >Generate font table: All fonts</_item> 
-        <_item value="sampleHW" >Generate font table: Handwriting-like</_item> 
-        <_item value="table"    >Generate glyph table in selected font</_item> 
+      <param indent="2" name="action" type="optiongroup" gui-text="Action: ">
+        <option value="render"   >Typeset that text</option>
+        <option value="sample"   >Generate font table: All fonts</option>
+        <option value="sampleHW" >Generate font table: Handwriting-like</option>
+        <option value="table"    >Generate glyph table in selected font</option>
       </param>
 
-      <param indent="2" name="fontface" type="enum" _gui-text="Font face: ">
-        <_item value="futural">Sans 1-stroke</_item>
-        <_item value="futuram">Sans bold</_item> 
+      <param indent="2" name="fontface" type="optiongroup" gui-text="Font face: ">
+        <option value="futural">Sans 1-stroke</option>
+        <option value="futuram">Sans bold</option>
 
-        <_item value="timesr">Serif medium</_item>
-        <_item value="timesi">Serif medium italic</_item>
-        <_item value="timesib">Serif bold italic</_item>
-        <_item value="timesrb">Serif bold</_item>
+        <option value="timesr">Serif medium</option>
+        <option value="timesi">Serif medium italic</option>
+        <option value="timesib">Serif bold italic</option>
+        <option value="timesrb">Serif bold</option>
 
-        <_item value="scripts">Script 1-stroke</_item>
-        <_item value="cursive">Script 1-stroke (alt)</_item>
-        <_item value="scriptc">Script medium</_item>
+        <option value="scripts">Script 1-stroke</option>
+        <option value="cursive">Script 1-stroke (alt)</option>
+        <option value="scriptc">Script medium</option>
 
-        <_item value="gothiceng">Gothic English</_item>
-        <_item value="gothicger">Gothic German</_item>
-        <_item value="gothicita">Gothic Italian</_item>	   
-        
+        <option value="gothiceng">Gothic English</option>
+        <option value="gothicger">Gothic German</option>
+        <option value="gothicita">Gothic Italian</option>
+
         <!-- Block below this are loosely adapted from fonts licensed under SIL Open Font License -->
-		<_item value="EMSAllure">EMS Allure</_item>
-		<_item value="EMSBird">EMS Bird</_item>
-		<_item value="EMSBirdSwashCaps">EMS Bird Swash Caps</_item>
-		<_item value="EMSBrush">EMS Brush</_item>
-		<_item value="EMSCapitol">EMS Capitol</_item>
-		<_item value="EMSCasualHand">EMS Casual Hand</_item>
-		<_item value="EMSDecorousScript">EMS Decorous Script</_item>
-		<_item value="EMSDelight">EMS Delight</_item>
-		<_item value="EMSDelightSwashCaps">EMS Delight Swash Caps</_item>
-		<_item value="EMSElfin">EMS Elfin</_item>
-		<_item value="EMSFelix">EMS Felix</_item>
-		<_item value="EMSHerculean">EMS Herculean</_item>
-		<_item value="EMSInvite">EMS Invite</_item>
-		<_item value="EMSLeague">EMS League</_item>
-		<_item value="EMSLittlePrincess">EMS Little Princess</_item>
-		<_item value="EMSMistyNight">EMS Misty Night</_item>
-		<_item value="EMSNeato">EMS Neato</_item>
-		<_item value="EMSNixish">EMS Nixish</_item>
-		<_item value="EMSNixishItalic">EMS Nixish Italic</_item>
-		<_item value="EMSOsmotron">EMS Osmotron</_item>
-		<_item value="EMSPancakes">EMS Pancakes</_item>
-		<_item value="EMSPepita">EMS Pepita</_item>
-		<_item value="EMSQwandry">EMS Qwandry</_item>
-		<_item value="EMSReadability">EMS Readability</_item>
-		<_item value="EMSReadabilityItalic">EMS Readability Italic</_item>
-		<_item value="EMSSociety">EMS Society</_item>
-		<_item value="EMSSwiss">EMS Swiss</_item>
-        <_item value="EMSTech">EMS Tech</_item> 
+		<option value="EMSAllure">EMS Allure</option>
+		<option value="EMSBird">EMS Bird</option>
+		<option value="EMSBirdSwashCaps">EMS Bird Swash Caps</option>
+		<option value="EMSBrush">EMS Brush</option>
+		<option value="EMSCapitol">EMS Capitol</option>
+		<option value="EMSCasualHand">EMS Casual Hand</option>
+		<option value="EMSDecorousScript">EMS Decorous Script</option>
+		<option value="EMSDelight">EMS Delight</option>
+		<option value="EMSDelightSwashCaps">EMS Delight Swash Caps</option>
+		<option value="EMSElfin">EMS Elfin</option>
+		<option value="EMSFelix">EMS Felix</option>
+		<option value="EMSHerculean">EMS Herculean</option>
+		<option value="EMSInvite">EMS Invite</option>
+		<option value="EMSLeague">EMS League</option>
+		<option value="EMSLittlePrincess">EMS Little Princess</option>
+		<option value="EMSMistyNight">EMS Misty Night</option>
+		<option value="EMSNeato">EMS Neato</option>
+		<option value="EMSNixish">EMS Nixish</option>
+		<option value="EMSNixishItalic">EMS Nixish Italic</option>
+		<option value="EMSOsmotron">EMS Osmotron</option>
+		<option value="EMSPancakes">EMS Pancakes</option>
+		<option value="EMSPepita">EMS Pepita</option>
+		<option value="EMSQwandry">EMS Qwandry</option>
+		<option value="EMSReadability">EMS Readability</option>
+		<option value="EMSReadabilityItalic">EMS Readability Italic</option>
+		<option value="EMSSociety">EMS Society</option>
+		<option value="EMSSwiss">EMS Swiss</option>
+        <option value="EMSTech">EMS Tech</option>
         <!-- Block above this are loosely adapted from fonts licensed under SIL Open Font License -->
 
-        <_item value="greek">Greek 1-stroke</_item>
-        <_item value="timesg">Greek medium</_item>
-        <_item value="cyrillic">Cyrillic</_item>		
-        <_item value="japanese">Japanese</_item> 
+        <option value="greek">Greek 1-stroke</option>
+        <option value="timesg">Greek medium</option>
+        <option value="cyrillic">Cyrillic</option>
+        <option value="japanese">Japanese</option>
 
-        <_item value="astrology">Astrology</_item>
-        <_item value="mathlow">Math (lower)</_item>
-        <_item value="mathupp">Math (upper)</_item>
-        <_item value="markers">Markers</_item> 
-        <_item value="meteorology">Meteorology</_item>
-        <_item value="music">Music</_item>
-        <_item value="symbolic">Symbolic</_item>
+        <option value="astrology">Astrology</option>
+        <option value="mathlow">Math (lower)</option>
+        <option value="mathupp">Math (upper)</option>
+        <option value="markers">Markers</option>
+        <option value="meteorology">Meteorology</option>
+        <option value="music">Music</option>
+        <option value="symbolic">Symbolic</option>
 
       </param>
-      <_param name="emptyspace" type="description" xml:space="preserve"> 
-</_param>
+      <label name="emptyspace" xml:space="preserve">
+</label>
 
     </page>
-    <page name="info" _gui-text="About Hershey Text">
-<_param indent="1" name="aboutTitle" type="description" appearance="header">Hershey Text 2.2</_param>
-<_param name="aboutpage" type="description" xml:space="preserve">This tool renders a line of text using specialized
+    <page name="info" gui-text="About Hershey Text">
+<label indent="1" name="aboutTitle" appearance="header">Hershey Text 2.2</label>
+<label name="aboutpage" xml:space="preserve">This tool renders a line of text using specialized
 "stroke" or "engraving" fonts designed for plotters. 
 
 Whereas regular "outline" fonts (e.g., TrueType) work
@@ -104,11 +104,11 @@ computer controlled drawing and cutting machines (from
 pen plotters to CNC routers) can efficiently follow. 
 
 For a full introduction, please visit:
-  www.evilmadscientist.com/go/hershey</_param>
+  www.evilmadscientist.com/go/hershey</label>
 </page>
 
-<page name="info" _gui-text="Credits">
-<_param name="aboutpage" type="description" xml:space="preserve">
+<page name="info" gui-text="Credits">
+<param name="aboutpage" xml:space="preserve">
 The classic fonts included -- those without the "EMS"
 prefix -- are derived from work by Dr. A. V. Hershey,
 distributed by the US National Bureau of Standards
@@ -125,14 +125,14 @@ For full credits and license information, please see
 the "hersheydata.py" file included with this
 distribution or visit:
    wiki.evilmadscientist.com/hershey
-</_param>
+</param>
 </page>
 </param>
 
   <effect needs-live-preview="true" needs-document="true">
     <object-type>all</object-type>
     <effects-menu>
-      <submenu _name="Render"/>
+      <submenu name="Render"/>
     </effects-menu>
   </effect>
     <script>

--- a/extensions/hershey.inx
+++ b/extensions/hershey.inx
@@ -10,20 +10,20 @@
   <param name="tab" type="notebook">
     <page name="splash" gui-text="Render Text">
 
-<label indent="1" name="splashpage" appearance="header">
+<label indent="1" appearance="header">
 Hershey Text: Engraving Fonts for Inkscape
 
 </label>
       <param indent="2" name="text" type="string" gui-text="Text:">The Quick Brown Fox Jumps Over a Lazy Dog</param>
 
-      <param indent="2" name="action" type="optiongroup" gui-text="Action: ">
+      <param indent="2" name="action" type="optiongroup" gui-text="Action: " appearance="combo">
         <option value="render"   >Typeset that text</option>
         <option value="sample"   >Generate font table: All fonts</option>
         <option value="sampleHW" >Generate font table: Handwriting-like</option>
         <option value="table"    >Generate glyph table in selected font</option>
       </param>
 
-      <param indent="2" name="fontface" type="optiongroup" gui-text="Font face: ">
+      <param indent="2" name="fontface" type="optiongroup" gui-text="Font face: " appearance="combo">
         <option value="futural">Sans 1-stroke</option>
         <option value="futuram">Sans bold</option>
 
@@ -85,13 +85,13 @@ Hershey Text: Engraving Fonts for Inkscape
         <option value="symbolic">Symbolic</option>
 
       </param>
-      <label name="emptyspace" xml:space="preserve">
+      <label xml:space="preserve">
 </label>
 
     </page>
     <page name="info" gui-text="About Hershey Text">
-<label indent="1" name="aboutTitle" appearance="header">Hershey Text 2.2</label>
-<label name="aboutpage" xml:space="preserve">This tool renders a line of text using specialized
+<label indent="1" appearance="header">Hershey Text 2.2</label>
+<label xml:space="preserve">This tool renders a line of text using specialized
 "stroke" or "engraving" fonts designed for plotters. 
 
 Whereas regular "outline" fonts (e.g., TrueType) work
@@ -108,7 +108,7 @@ For a full introduction, please visit:
 </page>
 
 <page name="info" gui-text="Credits">
-<param name="aboutpage" xml:space="preserve">
+<label xml:space="preserve">
 The classic fonts included -- those without the "EMS"
 prefix -- are derived from work by Dr. A. V. Hershey,
 distributed by the US National Bureau of Standards
@@ -125,7 +125,7 @@ For full credits and license information, please see
 the "hersheydata.py" file included with this
 distribution or visit:
    wiki.evilmadscientist.com/hershey
-</param>
+</label>
 </page>
 </param>
 
@@ -136,6 +136,6 @@ distribution or visit:
     </effects-menu>
   </effect>
     <script>
-      <command reldir="extensions" interpreter="python">hershey.py</command>
+      <command location="inx" interpreter="python">hershey.py</command>
     </script>
 </inkscape-extension>

--- a/extensions/hershey.py
+++ b/extensions/hershey.py
@@ -81,7 +81,7 @@ class Hershey( inkex.Effect ):
         g_attribs = {inkex.addNS('label','inkscape'):'Hershey Text' }
         g = lxml.etree.SubElement(self.current_layer, 'g', g_attribs)
 
-        scale = self.unittouu('1px')    # convert to document units
+        scale = self.svg.unittouu('1px')    # convert to document units
         font = eval('hersheydata.' + str(self.options.fontface))
         clearfont = hersheydata.futural  
         #Baseline: modernized roman simplex from JHF distribution.

--- a/extensions/hershey.py
+++ b/extensions/hershey.py
@@ -27,6 +27,8 @@ import hersheydata          #data file w/ Hershey font data
 import inkex
 import simplestyle
 
+import lxml.etree
+
 Debug = False
 FONT_GROUP_V_SPACING = 45
 
@@ -42,7 +44,7 @@ def draw_svg_text(char, face, offset, vertoffset, parent):
         pathString = pathString[splitpoint:] #portion after first move
         trans = 'translate(' + str(midpoint) + ',' + str(vertoffset) + ')'
         text_attribs = {'style':simplestyle.formatStyle(style), 'd':pathString, 'transform':trans}
-        inkex.etree.SubElement(parent, inkex.addNS('path','svg'), text_attribs) 
+        lxml.etree.SubElement(parent, inkex.addNS('path','svg'), text_attribs)
     return midpoint + float(splitString[1])   #new offset value
 
 def svg_text_width(char, face, offset):
@@ -77,7 +79,7 @@ class Hershey( inkex.Effect ):
 
         # Embed text in group to make manipulation easier:
         g_attribs = {inkex.addNS('label','inkscape'):'Hershey Text' }
-        g = inkex.etree.SubElement(self.current_layer, 'g', g_attribs)
+        g = lxml.etree.SubElement(self.current_layer, 'g', g_attribs)
 
         scale = self.unittouu('1px')    # convert to document units
         font = eval('hersheydata.' + str(self.options.fontface))

--- a/extensions/hershey.py
+++ b/extensions/hershey.py
@@ -109,7 +109,7 @@ class Hershey( inkex.Effect ):
             scale *= 0.5	#Typically scales to about A4/US Letter size
         else:
             #Generate glyph table
-            wmax = 0;
+            wmax = 0
             for p in range(0,10):
                 w = 0
                 v = spacing * (15*p - 67 )
@@ -141,7 +141,6 @@ class Hershey( inkex.Effect ):
         fontgroup = eval( 'hersheydata.' + fontgroupname )
         
         # Render list of font names in a vertical column:
-        nFontIndex = 0
         for f in fontgroup:
             w = 0
             letterVals = [ord(q) - 32 for q in (f[1] + ' -> ')]

--- a/extensions/hershey.py
+++ b/extensions/hershey.py
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
 import hersheydata          #data file w/ Hershey font data
 import inkex
-import simplestyle
+
 
 import lxml.etree
 
@@ -43,7 +43,7 @@ def draw_svg_text(char, face, offset, vertoffset, parent):
     if splitpoint > 0:
         pathString = pathString[splitpoint:] #portion after first move
         trans = 'translate(' + str(midpoint) + ',' + str(vertoffset) + ')'
-        text_attribs = {'style':simplestyle.formatStyle(style), 'd':pathString, 'transform':trans}
+        text_attribs = {'style':str(inkex.Style(style)), 'd':pathString, 'transform':trans}
         lxml.etree.SubElement(parent, inkex.addNS('path','svg'), text_attribs)
     return midpoint + float(splitString[1])   #new offset value
 

--- a/extensions/hershey.py
+++ b/extensions/hershey.py
@@ -178,6 +178,6 @@ class Hershey( inkex.Effect ):
 
 if __name__ == '__main__':
     e = Hershey()
-    e.affect()
+    e.run()
 
 # vim: expandtab shiftwidth=4 tabstop=8 softtabstop=4 fileencoding=utf-8 textwidth=99

--- a/extensions/hershey.py
+++ b/extensions/hershey.py
@@ -54,20 +54,20 @@ def svg_text_width(char, face, offset):
 class Hershey( inkex.Effect ):
     def __init__( self ):
         inkex.Effect.__init__( self )
-        self.OptionParser.add_option( "--tab",  #NOTE: value is not used.
-            action="store", type="string",
+        self.arg_parser.add_argument( "--tab",  #NOTE: value is not used.
+            type=str,
             dest="tab", default="splash",
             help="The active tab when Apply was pressed" )
-        self.OptionParser.add_option( "--text",
-            action="store", type="string", 
+        self.arg_parser.add_argument( "--text",
+            type=str,
             dest="text", default="Hershey Text for Inkscape",
             help="The input text to render")
-        self.OptionParser.add_option( "--action",
-            action="store", type="string",
+        self.arg_parser.add_argument( "--action",
+            type=str,
             dest="action", default="render",
             help="The active option when Apply was pressed" )
-        self.OptionParser.add_option( "--fontface",
-            action="store", type="string",
+        self.arg_parser.add_argument( "--fontface",
+            type=str,
             dest="fontface", default="rowmans",
             help="The selected font face when Apply was pressed" )
 

--- a/extensions/plot_utils.py
+++ b/extensions/plot_utils.py
@@ -31,7 +31,7 @@
 # SOFTWARE.
 
 from math import sqrt
-import cspsubdiv
+import inkex.bezier
 from bezmisc import *
 
 def version():
@@ -229,7 +229,7 @@ def subdivideCubicPath( sp, flat, i=1 ):
 	is approximately a straight line within a given tolerance
 	(the "smoothness" defined by [flat]).
 
-	This is a modified version of cspsubdiv.cspsubdiv(). I rewrote the recursive
+	This is a modified version of inkex.bezier.cspsubdiv(). I rewrote the recursive
 	call because it caused recursion-depth errors on complicated line segments.
 	"""
 
@@ -244,7 +244,7 @@ def subdivideCubicPath( sp, flat, i=1 ):
 
 			b = ( p0, p1, p2, p3 )
 
-			if cspsubdiv.maxdist( b ) > flat:
+			if inkex.bezier.maxdist( b ) > flat:
 				break
 			i += 1
 

--- a/extensions/plot_utils.py
+++ b/extensions/plot_utils.py
@@ -222,37 +222,6 @@ def unitsToUserUnits( inputString ):
 		# Unsupported units
 		return None
 
-def subdivideCubicPath( sp, flat, i=1 ):
-	"""
-	Break up a bezier curve into smaller curves, each of which
-	is approximately a straight line within a given tolerance
-	(the "smoothness" defined by [flat]).
-
-	This is a modified version of inkex.bezier.cspsubdiv(). I rewrote the recursive
-	call because it caused recursion-depth errors on complicated line segments.
-	"""
-
-	while True:
-		while True:
-			if i >= len( sp ):
-				return
-			p0 = sp[i - 1][1]
-			p1 = sp[i - 1][2]
-			p2 = sp[i][0]
-			p3 = sp[i][1]
-
-			b = ( p0, p1, p2, p3 )
-
-			if inkex.bezier.maxdist( b ) > flat:
-				break
-			i += 1
-
-		one, two = inkex.bezier.beziersplitatt( b, 0.5 )
-		sp[i - 1][2] = one[1]
-		sp[i][0] = two[2]
-		p = [one[2], one[3], two[1]]
-		sp[i:1] = [p]
-
 def userUnitToUnits(distanceUU, unitString ):
 	'''
 	Custom replacement for the uutounit routine in inkex.py

--- a/extensions/plot_utils.py
+++ b/extensions/plot_utils.py
@@ -32,7 +32,6 @@
 
 from math import sqrt
 import inkex.bezier
-from bezmisc import *
 
 def version():
 	return "0.9"	# Version number for this document
@@ -248,7 +247,7 @@ def subdivideCubicPath( sp, flat, i=1 ):
 				break
 			i += 1
 
-		one, two = beziersplitatt( b, 0.5 )
+		one, two = inkex.bezier.beziersplitatt( b, 0.5 )
 		sp[i - 1][2] = one[1]
 		sp[i][0] = two[2]
 		p = [one[2], one[3], two[1]]


### PR DESCRIPTION
Hello,

last easter holidays I found that some rewrites of the eggbot extension had become necessary for my one to continue to work:
- With [inkscape>=1.0](https://wiki.inkscape.org/wiki/index.php?title=Release_notes/1.0) (default e.g. in Archlinux and Ubuntu >=20.10) **major changes to the extension API** were introduced.
- python2 by now isn't supported anymore, so python2 compatibility may be dropped in favor of **needed python3 support**.

Thus, I
- went through the [inkscape updating instructions](https://wiki.inkscape.org/wiki/index.php/Updating_your_Extension_for_1.0) (and their compatibility source code) to eliminate usage of the deprecated old API and fix breaking changes, 
- fixed python3 issues I found, and
- fixed any remaining bugs I found.

I tried to keep the changes towards the new API minimal, for the concrete actions see the commit messages.

**My little EggBot now works again :-)**

I hope these adaptations are helpful to other proud owners of an EggBot e.g. from the [workshop at EasterHegg 2018](https://wiki.section77.de/projekte/eggbot77/eggbot77-2018-eh-edition). It would be great if you could make the updates available in the main or a side-branch, as your repo is linked from the workshop page.
Also, of course, any feedback is appreciated on issues I may have overlooked.

Thanks in advance and thanks a lot for providing the material in the first place!